### PR TITLE
Add "-Wconversion" to more closely align to MSVC

### DIFF
--- a/cmake/IgnSetCompilerFlags.cmake
+++ b/cmake/IgnSetCompilerFlags.cmake
@@ -126,7 +126,7 @@ macro(ign_setup_gcc_or_clang)
 
   ign_filter_valid_compiler_options(
     CUSTOM_ALL_FLAGS
-        -Wall -Wextra -Wno-long-long -Wno-unused-value -Wfloat-equal
+        -Wall -Wextra -Wno-long-long -Wno-unused-value -Wfloat-equal -Wconversion
         -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic
         )
 


### PR DESCRIPTION
This will make GCC builds warn on the same things that Windows does.  Unfortunately, it will also warn on more things, so I'm going to open this as a draft until the whole stack builds cleanly.

-  ign-utils: https://github.com/ignitionrobotics/ign-utils/pull/46