### PR TITLE
Remove deprecated CMake functions

### DIFF
--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -796,22 +796,6 @@ macro(ign_build_warning)
 endmacro(ign_build_warning)
 
 #################################################
-macro(ign_add_library lib_target_name)
-
-  message(FATAL_ERROR
-    "ign_add_library(<target_name> <sources>) is deprecated. Instead, use "
-    "ign_create_core_library(SOURCES <sources>). It will determine the library "
-    "target name automatically from the project name. To add a component "
-    "library, use ign_add_component(~). Be sure to pass the CXX_STANDARD "
-    "argument to these functions in order to set the C++ standard that they "
-    "require.")
-
-
-  ign_create_core_library(SOURCES ${ARGN})
-
-endmacro()
-
-#################################################
 # _ign_check_known_cxx_standards(<11|14|17>)
 #
 # Creates a fatal error if the variable passed in does not represent a supported
@@ -1501,15 +1485,6 @@ macro(ign_install_includes _subdir)
 endmacro()
 
 #################################################
-macro(ign_install_library)
-
-  message(FATAL_ERROR
-    "ign_install_library is deprecated. "
-    "Please remove it from your cmake script!")
-
-endmacro()
-
-#################################################
 macro(ign_install_executable _name )
   set_target_properties(${_name} PROPERTIES VERSION ${PROJECT_VERSION_FULL})
   install (TARGETS ${_name} DESTINATION ${IGN_BIN_INSTALL_DIR})
@@ -1748,32 +1723,6 @@ macro(ign_build_tests)
     message(STATUS "Testing is disabled -- skipping ${TEST_TYPE} tests")
 
   endif()
-
-endmacro()
-
-#################################################
-# ign_set_target_public_cxx_standard(<11|14|17>)
-#
-# NOTE: This was a temporary workaround for an earlier prerelease and is
-#       deprecated as of the "Components" pull request.
-#
-macro(ign_set_project_public_cxx_standard standard)
-
-  message(FATAL_ERROR
-    "The ign_set_project_public_cxx_standard(~) macro is deprecated. "
-    "Instead, use the CXX_STANDARD argument of ign_create_core_library(~).")
-
-  _ign_check_known_cxx_standards(${standard})
-
-  target_compile_features(${PROJECT_LIBRARY_TARGET_NAME} PUBLIC ${IGN_CXX_${standard}_FEATURES})
-
-  # Note: We have to reconfigure the pkg-config information for the core library
-  # because this macro can only be called after ign_create_core_library(~). This
-  # is somewhat wasteful, so we should strongly prefer to use the CXX_STANDARD
-  # argument of ign_create_core_library(~).
-
-  ign_string_append(PROJECT_PKGCONFIG_CFLAGS "-std=c++${standard}")
-  _ign_create_pkgconfig()
 
 endmacro()
 


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/719

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

These have been deprecated since `cmake2` and can be removed on `cmake3`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
