### PR TITLE
Cache finding python3

### DIFF
--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -16,7 +16,15 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
   set(IGN_PYTHON_VERSION "" CACHE STRING
     "Specify specific Python3 version to use ('major.minor' or 'versionMin...[<]versionMax')")
 
-  find_package(Python3 ${IGN_PYTHON_VERSION} QUIET)
+  if (NOT ${IGN_PYTHON3_FOUND})
+    find_package(Python3 ${IGN_PYTHON_VERSION} QUIET)
+
+    if (${Python3_FOUND})
+      set(IGN_PYTHON_FOUND "True" CACHE INTERNAL)
+    endif()
+  endif()
+
+
 elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
   # no support for finding specific versions
   find_package(Python3 QUIET)


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# 🦟 Bug fix

## Summary

Repeated calls of IgnPython find python3 even if it has already been found, which inflates build time.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
