### PR TITLE
Fix package argument in manual search macro

### DIFF
--- a/cmake/IgnManualSearch.cmake
+++ b/cmake/IgnManualSearch.cmake
@@ -51,9 +51,9 @@ macro(ign_manual_search package)
   _gz_cmake_parse_arguments(gz_manual_search "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   set(gz_manual_search_skip_parsing true)
-  gz_manual_search(${PACKAGE_NAME})
+  gz_manual_search(${package})
 endmacro()
-macro(gz_manual_search PACKAGE_NAME)
+macro(gz_manual_search package)
 
   # Deprecated, remove skip parsing logic in version 4
   if (NOT gz_manual_search_skip_parsing)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-common/issues/386 and typo from https://github.com/gazebosim/gz-cmake/pull/255

## Summary

The package argument to `ign_manual_search` / `gz_manual_search` is `package` in everywhere except two places where it is `PACKAGE_NAME`. I believe this typo is the cause of https://github.com/gazebosim/gz-common/issues/386 and am testing this fix in https://github.com/gazebosim/gz-common/pull/387

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
