### PR TITLE
Exclude proto generated files in coverage test

### DIFF
--- a/cmake/IgnCodeCoverage.cmake
+++ b/cmake/IgnCodeCoverage.cmake
@@ -132,7 +132,7 @@ FUNCTION(ign_setup_target_for_coverage)
     # Remove negative counts
     COMMAND sed -i '/,-/d' ${_outputname}.info
     COMMAND ${LCOV_PATH} ${_branch_flags} -q
-      --remove ${_outputname}.info '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' --output-file ${_outputname}.info.cleaned
+      --remove ${_outputname}.info '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' '*.pb.*' --output-file ${_outputname}.info.cleaned
     COMMAND ${GENHTML_PATH} ${_branch_flags} -q
     --legend -o ${_outputname} ${_outputname}.info.cleaned
     COMMAND ${LCOV_PATH} --summary ${_outputname}.info.cleaned 2>&1 | grep "lines" | cut -d ' ' -f 4 | cut -d '%' -f 1 > ${_outputname}/lines.txt


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

Increase the test coverage rate for gz-msgs5 from ~18% to ~85%. 

* Part of https://github.com/gazebosim/gz-sim/issues/1575

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

All codes generated by proto all follow this pattern: `*.pb.cc` or `*.pb.h`

To test this, follow https://gazebosim.org/docs/all/contributing#test-coverage to generate coverage report for gz-msgs5

Before:
![image](https://user-images.githubusercontent.com/50132891/178057394-0dfc0d2d-c831-42fc-9472-935be8e36018.png)

After:
![20220708141640](https://user-images.githubusercontent.com/50132891/178057436-83442662-97c4-446c-8c84-2bf230f795c8.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
