### PR TITLE
Prepare for 2.13.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.12.1)
+project(ignition-cmake2 VERSION 2.13.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,29 @@
 ## Ignition CMake 2.x
 
+### Ignition CMake 2.13.0 (2022-07-22)
+
+1. Backport `GZ_DESIGNATION` tick-tock
+    * [Pull request #284](https://github.com/gazebosim/gz-cmake/pull/284)
+
+1. Upload docs to an s3 bucket based only on the major version
+    * [Pull request #281](https://github.com/gazebosim/gz-cmake/pull/281)
+
+1. Exclude proto generated cpp in coverage test
+    * [Pull request #272](https://github.com/gazebosim/gz-cmake/pull/272)
+
+1. Add LTCG flag on Windows builds
+    * [Pull request #251](https://github.com/gazebosim/gz-cmake/pull/251)
+
+1. Update codeowners
+    * [Pull request #261](https://github.com/gazebosim/gz-cmake/pull/261)
+    * [Pull request #237](https://github.com/gazebosim/gz-cmake/pull/237)
+
+1. Update documentation to gazebosim.org
+    * [Pull request #248](https://github.com/gazebosim/gz-cmake/pull/248)
+
+1. Improving CONFIG test
+    * [Pull request #235](https://github.com/gazebosim/gz-cmake/pull/235)
+
 ### Ignition CMake 2.12.1 (2022-04-12)
 
 1. Allow to recreate targets created by IgnPkgConfig


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.13.0 release.

Comparison to 2.13.0: https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.12.1...ign-cmake2

<!-- Add links to PRs that require this release (if needed) -->
Needed by

* https://github.com/gazebosim/gz-math/pull/468
* https://github.com/gazebosim/gz-plugin/pull/96
* https://github.com/gazebosim/gz-common/pull/399
* and other PRs that reference https://github.com/gazebosim/gz-cmake/pull/282

## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [X] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
