### PR TITLE
Add FindCSV.cmake module

### DIFF
--- a/cmake/FindCSV.cmake
+++ b/cmake/FindCSV.cmake
@@ -1,0 +1,31 @@
+#===============================================================================
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################
+# Find libcsv
+include(GzPkgConfig)
+gz_pkg_check_modules_quiet(CSV libcsv)
+
+if(NOT CSV_FOUND)
+  include(GzManualSearch)
+  gz_manual_search(CSV
+                   HEADER_NAMES "csv.h"
+                   LIBRARY_NAMES "csv")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  CSV
+  REQUIRED_VARS CSV_FOUND)


### PR DESCRIPTION
# 🎉 New feature

## Summary
This patch adds a CMake module for [libcsv-dev](https://packages.debian.org/sid/libdevel/libcsv-dev).

## Test it
<!--Explain how reviewers can test this new feature manually.-->
See https://github.com/gazebosim/gz-common/pull/402.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
