### PR TITLE
Change FindGzAssimp to use find_package

### DIFF
--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -23,13 +23,19 @@ find_package(assimp CONFIG QUIET)
 set(GzAssimp_FOUND ${assimp_FOUND})
 set(GzAssimp_LIBRARIES ${ASSIMP_LIBRARIES})
 set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
-set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
 set(GzAssimp_VERSION ${assimp_VERSION})
 
 include(GzPkgConfig)
 gz_pkg_config_entry(GzAssimp "assimp")
 
+# Clear cached variables so downstream packages will trigger a find
+unset(assimp_FOUND CACHE)
+unset(ASSIMP_INCLUDE_DIRS CACHE)
+unset(ASSIMP_LIBRARIES CACHE)
+unset(ASSIMP_VERSION CACHE)
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   GzAssimp
-  REQUIRED_VARS GzAssimp_FOUND)
+  REQUIRED_VARS GzAssimp_FOUND GzAssimp_INCLUDE_DIRS GzAssimp_LIBRARIES
+  VERSION_VAR GzAssimp_VERSION)

--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -15,41 +15,10 @@
 #
 ########################################
 # Find Assimp
+# Provides a GzAssimp alias to avoid conflicts with other packages
+# that might provide a FindAssimp function, such as dartsim
 
-include(GzPkgConfig)
-
-message("Looking for assimp")
-
-#if(GzAssimp_FIND_VERSION)
-#  gz_pkg_check_modules_quiet(GzAssimp "assimp >= ${GzAssimp_FIND_VERSION}")
-#else()
-#  gz_pkg_check_modules_quiet(GzAssimp "assimp")
-#endif()
-
-#if(NOT GzAssimp_FOUND)
-if(WIN32)
-#  message("Doing manual search")
-#  include(GzManualSearch)
-#  gz_manual_search(GzAssimp
-#                   HEADER_NAMES "assimp/scene.h"
-#                   LIBRARY_NAMES "assimp"
-#		   TARGET_NAME "GzAssimp::GzAssimp")
-#  find_library(TMP_ASSIMP_LIB "assimp-vc-141-mt")
-#  message("TMP ASSIMP LIB IS ${TMP_ASSIMP_LIB}")
-#
-#   gz_pkg_config_entry(GzAssimp "assimp")
-endif()
 find_package(assimp CONFIG QUIET)
-
-message("GzAssimp found ${GzAssimp_FOUND}")
-message("GzAssimp libs ${GzAssimp_LIBRARIES}")
-message("GzAssimp include dirs ${GzAssimp_INCLUDE_DIRS}")
-message("GzAssimp version ${GzAssimp_VERSION}")
-
-message("Assimp found ${assimp_FOUND}")
-message("Assimp libs ${ASSIMP_LIBRARIES}")
-message("Assimp include dirs ${ASSIMP_INCLUDE_DIRS}")
-message("Assimp version ${assimp_VERSION}")
 
 set(GzAssimp_FOUND ${assimp_FOUND})
 set(GzAssimp_LIBRARIES ${ASSIMP_LIBRARIES})
@@ -57,9 +26,8 @@ set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
 set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
 set(GzAssimp_VERSION ${assimp_VERSION})
 
+include(GzPkgConfig)
 gz_pkg_config_entry(GzAssimp "assimp")
-#mark_as_advanced(GzAssimp_LIBRARY_assimp)
-#set(GzAssimp_LIBRARY_assimp ${GzAssimp_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -21,7 +21,11 @@
 find_package(assimp CONFIG QUIET)
 
 set(GzAssimp_FOUND ${assimp_FOUND})
-set(GzAssimp_LIBRARIES ${ASSIMP_LIBRARIES})
+if (MSVC)
+  set(GzAssimp_LIBRARIES assimp::assimp)
+else()
+  set(GzAssimp_LIBRARIES ${ASSIMP_LIBRARIES})
+endif()
 set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
 set(GzAssimp_VERSION ${assimp_VERSION})
 
@@ -37,5 +41,5 @@ unset(ASSIMP_VERSION CACHE)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   GzAssimp
-  REQUIRED_VARS GzAssimp_FOUND GzAssimp_INCLUDE_DIRS GzAssimp_LIBRARIES
+  REQUIRED_VARS GzAssimp_FOUND
   VERSION_VAR GzAssimp_VERSION)

--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -18,19 +18,50 @@
 
 include(GzPkgConfig)
 
-if(ASSIMP_FIND_VERSION)
-  gz_pkg_check_modules_quiet(GzAssimp "assimp >= ${ASSIMP_FIND_VERSION}")
-else()
-  gz_pkg_check_modules_quiet(GzAssimp "assimp")
-endif()
+message("Looking for assimp")
 
-if(NOT ASSIMP_FOUND)
-  include(GzManualSearch)
-  gz_manual_search(ASSIMP
-                   HEADER_NAMES "assimp/scene.h"
-                   LIBRARY_NAMES "assimp")
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(
-    GzAssimp
-    REQUIRED_VARS GzAssimp_FOUND)
+#if(GzAssimp_FIND_VERSION)
+#  gz_pkg_check_modules_quiet(GzAssimp "assimp >= ${GzAssimp_FIND_VERSION}")
+#else()
+#  gz_pkg_check_modules_quiet(GzAssimp "assimp")
+#endif()
+
+#if(NOT GzAssimp_FOUND)
+if(WIN32)
+#  message("Doing manual search")
+#  include(GzManualSearch)
+#  gz_manual_search(GzAssimp
+#                   HEADER_NAMES "assimp/scene.h"
+#                   LIBRARY_NAMES "assimp"
+#		   TARGET_NAME "GzAssimp::GzAssimp")
+#  find_library(TMP_ASSIMP_LIB "assimp-vc-141-mt")
+#  message("TMP ASSIMP LIB IS ${TMP_ASSIMP_LIB}")
+#
+#   gz_pkg_config_entry(GzAssimp "assimp")
 endif()
+find_package(assimp CONFIG QUIET)
+
+message("GzAssimp found ${GzAssimp_FOUND}")
+message("GzAssimp libs ${GzAssimp_LIBRARIES}")
+message("GzAssimp include dirs ${GzAssimp_INCLUDE_DIRS}")
+message("GzAssimp version ${GzAssimp_VERSION}")
+
+message("Assimp found ${assimp_FOUND}")
+message("Assimp libs ${ASSIMP_LIBRARIES}")
+message("Assimp include dirs ${ASSIMP_INCLUDE_DIRS}")
+message("Assimp version ${assimp_VERSION}")
+
+set(GzAssimp_FOUND ${assimp_FOUND})
+set(GzAssimp_LIBRARIES ${ASSIMP_LIBRARIES})
+set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
+set(GzAssimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIRS})
+set(GzAssimp_VERSION ${assimp_VERSION})
+
+gz_pkg_config_entry(GzAssimp "assimp")
+#mark_as_advanced(GzAssimp_LIBRARY_assimp)
+#set(GzAssimp_LIBRARY_assimp ${GzAssimp_LIBRARIES})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  GzAssimp
+  REQUIRED_VARS GzAssimp_FOUND)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The previous implementation of FindGzAssimp had issues on Windows, specifically on Windows it seems that it is necessary to use `find_package` instead of `pkg-config`, i.e. vcpkg prints the following:

```
The package assimp provides CMake targets:

    find_package(assimp CONFIG REQUIRED)
    target_link_libraries(main PRIVATE assimp::assimp)
```

but using `find_package` sets global variables that break downstream users that reimplement their own version of `FindAssimp` such as dartsim.

For these reasons the implementation now uses find_package but clears the cache from the `assimp` variables and only uses the `GzAssimp` namespaced variables. Downstream behavior is now unchanged.

Tested with the [gz-common PR](https://github.com/gazebosim/gz-common/pull/408) to make sure CI is :heavy_check_mark: 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.