### PR TITLE
Override CMP0012 policy for Assimp

### DIFF
--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -18,6 +18,8 @@
 # Provides a GzAssimp alias to avoid conflicts with other packages
 # that might provide a FindAssimp function, such as dartsim
 
+# Set CMP0012 policy to NEW to avoid OLD policy warning in assimp 5.0.1
+set(CMAKE_POLICY_DEFAULT_CMP0012 NEW)
 find_package(assimp CONFIG QUIET)
 
 set(GzAssimp_FOUND ${assimp_FOUND})


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Assimp versions 5.0.x have an `if(ON)` statement that results in the following warning:

```
CMake Warning (dev) at /usr/lib/x86_64-linux-gnu/cmake/assimp-5.0/assimpTargets.cmake:54 (if):
  if given arguments:

    "ON"

  An argument named "ON" appears in a conditional statement.  Policy CMP0012
  is not set: if() recognizes numbers and boolean constants.  Run "cmake
  --help-policy CMP0012" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/assimp-5.0/assimp-config.cmake:1 (include)
  /home/luca/ws_garden/install/share/cmake/gz-cmake3/cmake3/FindGzAssimp.cmake:21 (find_package)
  /home/luca/ws_garden/install/lib/cmake/gz-common5-graphics/gz-common5-graphics-config.cmake:105 (find_package)
  /usr/share/cmake-3.16/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /home/luca/ws_garden/install/lib/cmake/gz-common5/gz-common5-config.cmake:188 (find_dependency)
  /home/luca/ws_garden/install/lib/cmake/gz-rendering7/gz-rendering7-config.cmake:93 (find_package)
  /home/luca/ws_garden/install/lib/cmake/gz-gui7/gz-gui7-config.cmake:99 (find_package)
  /home/luca/ws_garden/install/share/cmake/gz-cmake3/cmake3/GzUtils.cmake:231 (find_package)
  CMakeLists.txt:101 (gz_find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR sets the policy to NEW to suppress the warning

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.