### PR TITLE
Backport GZ_SANITIZER variable

### DIFF
--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -17,7 +17,7 @@
 
 include(CheckCXXSourceCompiles)
 
-set(GZ_SANITIZER ""  # Back-ported from gz-cmake3
+set(GZ_SANITIZER ""
     CACHE STRING
     "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -22,7 +22,7 @@ set(GZ_SANITIZER ""
     "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )
 
-set(IGN_SANITIZER ""
+set(IGN_SANITIZER ""  # TODO(CH3): Deprecated. Remove on tock.
   CACHE STRING
   "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )
@@ -54,7 +54,7 @@ function(test_san_flags return_var flags)
   set(CMAKE_REQUIRED_QUIET "${QUIET_BACKUP}")
 endfunction()
 
-if(NOT GZ_SANITIZER AND IGN_SANITIZER)
+if(NOT GZ_SANITIZER AND IGN_SANITIZER)  # TODO(CH3): Deprecated. Remove on tock.
   set(GZ_SANITIZER ${IGN_SANITIZER})
 endif()
 

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -17,9 +17,14 @@
 
 include(CheckCXXSourceCompiles)
 
-set(IGN_SANITIZER ""
+set(GZ_SANITIZER ""  # Back-ported from gz-cmake3
     CACHE STRING
     "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
+)
+
+set(IGN_SANITIZER ""
+  CACHE STRING
+  "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )
 
 function(append value)
@@ -49,13 +54,17 @@ function(test_san_flags return_var flags)
   set(CMAKE_REQUIRED_QUIET "${QUIET_BACKUP}")
 endfunction()
 
-if(IGN_SANITIZER)
+if(NOT GZ_SANITIZER AND IGN_SANITIZER)
+  set(GZ_SANITIZER ${IGN_SANITIZER})
+endif()
+
+if(GZ_SANITIZER)
   append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
   unset(SANITIZER_SELECTED_FLAGS)
 
   if(UNIX)
-    if(IGN_SANITIZER MATCHES "([Aa]ddress)")
+    if(GZ_SANITIZER MATCHES "([Aa]ddress)")
       # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
       message(STATUS "Testing with Address sanitizer")
       set(SANITIZER_ADDR_FLAG "-fsanitize=address")
@@ -75,10 +84,10 @@ if(IGN_SANITIZER)
       endif()
     endif()
 
-    if(IGN_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+    if(GZ_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
       # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
       set(SANITIZER_MEM_FLAG "-fsanitize=memory")
-      if(IGN_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+      if(GZ_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
         message(STATUS "Testing with MemoryWithOrigins sanitizer")
         append("-fsanitize-memory-track-origins" SANITIZER_MEM_FLAG)
       else()
@@ -86,7 +95,7 @@ if(IGN_SANITIZER)
       endif()
       test_san_flags(SANITIZER_MEM_AVAILABLE ${SANITIZER_MEM_FLAG})
       if(SANITIZER_MEM_AVAILABLE)
-        if(IGN_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+        if(GZ_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
           message(STATUS "  Building with MemoryWithOrigins sanitizer")
         else()
           message(STATUS "  Building with Memory sanitizer")
@@ -105,7 +114,7 @@ if(IGN_SANITIZER)
       endif()
     endif()
 
-    if(IGN_SANITIZER MATCHES "([Uu]ndefined)")
+    if(GZ_SANITIZER MATCHES "([Uu]ndefined)")
       message(STATUS "Testing with Undefined Behaviour sanitizer")
       set(SANITIZER_UB_FLAG "-fsanitize=undefined")
       if(EXISTS "${BLACKLIST_FILE}")
@@ -128,7 +137,7 @@ if(IGN_SANITIZER)
       endif()
     endif()
 
-    if(IGN_SANITIZER MATCHES "([Tt]hread)")
+    if(GZ_SANITIZER MATCHES "([Tt]hread)")
       message(STATUS "Testing with Thread sanitizer")
       set(SANITIZER_THREAD_FLAG "-fsanitize=thread")
       test_san_flags(SANITIZER_THREAD_AVAILABLE ${SANITIZER_THREAD_FLAG})
@@ -147,7 +156,7 @@ if(IGN_SANITIZER)
       endif()
     endif()
 
-    if(IGN_SANITIZER MATCHES "([Ll]eak)")
+    if(GZ_SANITIZER MATCHES "([Ll]eak)")
       message(STATUS "Testing with Leak sanitizer")
       set(SANITIZER_LEAK_FLAG "-fsanitize=leak")
       test_san_flags(SANITIZER_LEAK_AVAILABLE ${SANITIZER_LEAK_FLAG})
@@ -166,7 +175,7 @@ if(IGN_SANITIZER)
       endif()
     endif()
 
-    if(IGN_SANITIZER MATCHES "([Cc][Ff][Ii])")
+    if(GZ_SANITIZER MATCHES "([Cc][Ff][Ii])")
       message(STATUS "Testing with Control Flow Integrity(CFI) sanitizer")
       set(SANITIZER_CFI_FLAG "-fsanitize=cfi")
       test_san_flags(SANITIZER_CFI_AVAILABLE ${SANITIZER_CFI_FLAG})
@@ -197,7 +206,7 @@ if(IGN_SANITIZER)
           " Sanitizer flags ${SANITIZER_SELECTED_FLAGS} are not compatible.")
     endif()
   elseif(MSVC)
-    if(IGN_SANITIZER MATCHES "([Aa]ddress)")
+    if(GZ_SANITIZER MATCHES "([Aa]ddress)")
       message(STATUS "Building with Address sanitizer")
       append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
@@ -208,11 +217,11 @@ if(IGN_SANITIZER)
     else()
       message(
         FATAL_ERROR
-          "This sanitizer not yet supported in the MSVC environment: ${IGN_SANITIZER}"
+          "This sanitizer not yet supported in the MSVC environment: ${GZ_SANITIZER}"
       )
     endif()
   else()
-    message(FATAL_ERROR "IGN_SANITIZER is not supported on this platform.")
+    message(FATAL_ERROR "GZ_SANITIZER is not supported on this platform.")
   endif()
 
 endif()


### PR DESCRIPTION
# 🎉 New feature

Backport a feature to simplify the fixing of cmake deprecation warnings in CI

## Summary

This backports the `GZ_SANITIZER` variable so that it can be used in [jenkins](https://github.com/gazebo-tooling/release-tools/blob/127137e924eb21ec16ec303d9da0da464420de2a/jenkins-scripts/dsl/ignition.dsl#L435) and fix some cmake deprecation warnings.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci_asan-main-focal-amd64&build=15)](https://build.osrfoundation.org/job/ignition_cmake-ci_asan-main-focal-amd64/15/) https://build.osrfoundation.org/job/ignition_cmake-ci_asan-main-focal-amd64/15/

~~~
CMake Deprecation Warning at cmake/GzSanitizers.cmake:58 (message):
  Ign prefixed variable [IGN_SANITIZER] is deprecated! Use [GZ_SANITIZER]
  instead!
Call Stack (most recent call first):
  cmake/GzCMake.cmake:33 (include)
  CMakeLists.txt:19 (include)
~~~

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
