### PR TITLE
Prepare for 2.15.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.14.0)
+project(ignition-cmake2 VERSION 2.15.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## Ignition CMake 2.x
 
+### Ignition CMake 2.15.0 (2022-08-29)
+
+1. ign -> gz: add `gz/*` header files
+    * [Pull request #303](https://github.com/gazebosim/gz-cmake/pull/303)
+
+1. Backport `GZ_SANITIZER` variable
+    * [Pull request #294](https://github.com/gazebosim/gz-cmake/pull/294)
+
+1. Update doxygen file
+    * [Pull request #276](https://github.com/gazebosim/gz-cmake/pull/276)
+
 ### Ignition CMake 2.14.0 (2022-07-25)
 
 1. Add code coverage ignore file


### PR DESCRIPTION
# 🎈 2.15.0 Release

Preparation for 2.15.0 release.

Comparison to 2.14.0: https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.14.0...ign-cmake2

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-plugin/pull/101 and others from https://github.com/gazebo-tooling/release-tools/issues/784

## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
