### PR TITLE
Remove check for s3cfg

### DIFF
--- a/cmake/upload_doc.sh.in
+++ b/cmake/upload_doc.sh.in
@@ -3,13 +3,6 @@
 echo "Usage: sh upload_doc.sh [y/n]"
 echo "  Optional [y/n] argument indicates whether to upload the docs to S3 automatically."
 
-# Check if the node was configured to use s3cmd
-# This is done by running s3cmd --configure
-if [ ! -f "${HOME}/.s3cfg" ]; then
-    echo "No $HOME/.s3cfg file found. Please config the software first in your system"
-    exit 1
-fi
-
 # Make documentation if not build
 if [ ! -f "@CMAKE_BINARY_DIR@/doxygen/html/index.html" ]; then
   make doc


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

I moved the `upload_doc.sh` script from `s3cfg` to the aws CLI tool and forgot to remove the s3cfg check. This check is no longer needed, and prevents the nightly documentation job from completing successfully.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.