### PR TITLE
FindUUID: Do not wrap LIBRARY_NAMES argument with quotes

### DIFF
--- a/cmake/FindUUID.cmake
+++ b/cmake/FindUUID.cmake
@@ -23,9 +23,9 @@ if (UNIX)
     if(NOT UUID_FOUND)
       include(IgnManualSearch)
       ign_manual_search(UUID
-                        HEADER_NAMES "uuid.h"
-                        LIBRARY_NAMES "uuid libuuid"
-                        PATH_SUFFIXES "uuid")
+                        HEADER_NAMES uuid.h
+                        LIBRARY_NAMES uuid libuuid
+                        PATH_SUFFIXES uuid)
     endif()
 
     # The pkg-config or the manual search will place


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/conda-forge/libignition-cmake0-feedstock/issues/32 .

## Summary

Apparently `FindUUID` does not find uuid if pkg-config is not installed in the system, even if https://github.com/gazebosim/gz-cmake/pull/95 should have added support for this. This was due to a bug in https://github.com/gazebosim/gz-cmake/pull/95 that is fixed in this PR: multiple arguments to a parameter should not be passed inside quotes, otherwise there are considered as a single parameter.

For consistency, I also removed the quotes from the other arguments to the same function call.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
