### PR TITLE
Fix FindAVDEVICE.cmake in case without pkg-config installed with ffmpeg >= 5.1

### DIFF
--- a/cmake/FindAVDEVICE.cmake
+++ b/cmake/FindAVDEVICE.cmake
@@ -32,6 +32,13 @@ if(NOT AVDEVICE_FOUND)
   if(AVDEVICE_FOUND)
     file(READ "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version.h" ver_file)
 
+    # ffmpeg 5.1 splitted version information in two files
+    # https://github.com/FFmpeg/FFmpeg/commit/884c5976592c2d8084e8c9951c94ddf04019d81d
+    if(EXISTS "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version_major.h")
+      file(READ "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version_major.h" ver_major_file)
+      string(CONCAT ver_file ${ver_file} ${ver_major_file})
+    endif()
+
     string(REGEX MATCH "LIBAVDEVICE_VERSION_MAJOR[ \t\r\n]+([0-9]*)" _ ${ver_file})
     set(ver_major ${CMAKE_MATCH_1})
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

ffmpeg 5.1 changed the structure of version headers (see https://github.com/FFmpeg/FFmpeg/commit/884c5976592c2d8084e8c9951c94ddf04019d81d), this PR fixes `FindAVDEVICE.cmake` to work correctly (i.e. finding the version number) even in the case in which no pkg-config is installed in the system.

The GitHub online editor also added a newline at the end of the file, let me know if it is ok to leave it, otherwise I can look how to remove it. I tried but apparently it is not possible anymore to commit a change via GitHub online editor without having automatically added a newline at the end of file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.