### PR TITLE
Add optional binary relocatability in downstream libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
-          cmake-args: '-DBUILDSYSTEM_TESTING=True'
+          cmake-args: '-DBUILDSYSTEM_TESTING=True -DGZ_ENABLE_RELOCATABLE_INSTALL=True'
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Gazebo CMake 3.x
 
+1. Add optional binary relocatability in downstream libraries
+    * [Pull request #334](https://github.com/gazebosim/gz-cmake/pull/334)
+
 ### Gazebo CMake 3.0.1 (2022-10-11)
 
 1. 1. FindIgnOGRE2: preserve PKG_CONFIG_PATH

--- a/cmake/GzUtils.cmake
+++ b/cmake/GzUtils.cmake
@@ -2003,6 +2003,20 @@ endmacro()
 #
 # To use this macro, please add gz_find_package(DL)
 # in the dependencies of your project
+#
+# Arguments are as follows:
+#
+# GET_INSTALL_PREFIX_FUNCTION: Required. The name (with namespace) of the function that returns
+#          the install directory of the package. Example: gz::${GZ_DESIGNATION}::getInstallPrefix
+#
+# GET_INSTALL_PREFIX_HEADER: Required. The name (with full relative path) of the include that contains
+#          the declaration of the ${GET_INSTALL_PREFIX_FUNCTION} function.
+#          Example: gz/${GZ_DESIGNATION}/InstallationDirectories.hh
+#
+# OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE: Required. The name of the environmental variable that can be
+#          used to override the value returned by ${GET_INSTALL_PREFIX_FUNCTION} at runtime.
+#          Example: GZ_${GZ_DESIGNATION_UPPER}_INSTALL_PREFIX
+
 macro(gz_add_get_install_prefix_impl)
   set(_options)
   set(_oneValueArgs
@@ -2068,6 +2082,12 @@ macro(gz_add_get_install_prefix_impl)
 
 #include <${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_HEADER}>
 
+#ifdef _MSC_VER
+  // Disable warnings related to the use of std::getenv
+  // See https://stackoverflow.com/questions/66090389/c17-what-new-with-error-c4996-getenv-this-function-or-variable-may-be-un
+  #pragma warning(disable: 4996)
+#endif
+
 std::string ${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_FUNCTION}()
 {
   if(const char* override_env_var = std::getenv(\"${gz_add_get_install_prefix_impl_OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE}\"))
@@ -2116,6 +2136,10 @@ std::string ${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_FUNCTION}()
   // Return install prefix
   return install_prefix_canonical.string();
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 ")
   else()
     # For static library, fallback to just provide return CMAKE_INSTALL_PREFIX
@@ -2126,6 +2150,13 @@ std::string ${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_FUNCTION}()
 
 #include <${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_HEADER}>
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Disable warnings related to the use of std::getenv
+  // See https://stackoverflow.com/questions/66090389/c17-what-new-with-error-c4996-getenv-this-function-or-variable-may-be-un
+  #pragma warning(disable: 4996)
+#endif
+
 std::string ${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_FUNCTION}()
 {
   if(const char* override_env_var = std::getenv(\"${gz_add_get_install_prefix_impl_OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE}\"))
@@ -2135,6 +2166,10 @@ std::string ${gz_add_get_install_prefix_impl_GET_INSTALL_PREFIX_FUNCTION}()
 
   return \"${CMAKE_INSTALL_PREFIX}\";
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 ")
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,3 +7,9 @@ if (UNIX)
     ${CMAKE_BINARY_DIR}/test_results
   )
 endif()
+
+# This test requires the use of std::filesystem, so it is only compiled on non-GCC
+# compilers of with GCC >= 11
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0)
+  add_subdirectory(get_install_prefix)
+endif()

--- a/test/get_install_prefix/CMakeLists.txt
+++ b/test/get_install_prefix/CMakeLists.txt
@@ -1,0 +1,60 @@
+# For the tests, we make sure that the relative path in the build location is the same
+# of the install, and we make sure that the value returned by the shared library is ${CMAKE_BINARY_DIR}
+# while for the static library we make sure that the value returned is ${CMAKE_INSTALL_PREFIX}
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+include(GzUtils)
+
+# dladdr from dl is a compulsory requirement for
+# gz_add_get_install_prefix_impl
+gz_find_package(DL REQUIRED)
+
+# shared test
+add_library(get-install-prefix-test-shared SHARED)
+set(PROJECT_LIBRARY_TARGET_NAME get-install-prefix-test-shared)
+
+gz_add_get_install_prefix_impl(GET_INSTALL_PREFIX_HEADER get_install_prefix_test_shared.h
+                               GET_INSTALL_PREFIX_FUNCTION gz::cmake::test::sharedlib::getInstallPrefix
+                               OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE GET_INSTALL_PREFIX_TEST_INSTALL_PREFIX)
+set_target_properties(get-install-prefix-test-shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_include_directories(get-install-prefix-test-shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(get-install-prefix-test-shared PRIVATE cxx_std_17)
+
+
+# static test
+add_library(get-install-prefix-test-static STATIC)
+set(PROJECT_LIBRARY_TARGET_NAME get-install-prefix-test-static)
+
+gz_add_get_install_prefix_impl(GET_INSTALL_PREFIX_HEADER get_install_prefix_test_static.h
+                               GET_INSTALL_PREFIX_FUNCTION gz::cmake::test::staticlib::getInstallPrefix
+                               OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE GET_INSTALL_PREFIX_TEST_INSTALL_PREFIX)
+target_include_directories(get-install-prefix-test-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(get-install-prefix-test-static PRIVATE cxx_std_17)
+
+
+# Write header with CMake variables to check
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/get_install_prefix_test_cmake_variables.h
+"#pragma once
+
+#define CMAKE_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\"
+#define CMAKE_BINARY_DIR \"${CMAKE_BINARY_DIR}\"
+
+")
+
+
+
+# Add test executable
+add_executable(get_install_prefix_test get_install_prefix_test.cc)
+target_include_directories(get_install_prefix_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(get_install_prefix_test PRIVATE get-install-prefix-test-shared
+                                                      get-install-prefix-test-static)
+target_compile_features(get_install_prefix_test PRIVATE cxx_std_17)
+
+# Add the test only if GZ_ENABLE_RELOCATABLE_INSTALL is enabled,
+# as the test on gz_add_get_install_prefix_impl rely on GZ_ENABLE_RELOCATABLE_INSTALL
+# being enabled
+if(GZ_ENABLE_RELOCATABLE_INSTALL)
+  add_test(NAME get_install_prefix_test COMMAND get_install_prefix_test)
+endif()

--- a/test/get_install_prefix/get_install_prefix_test.cc
+++ b/test/get_install_prefix/get_install_prefix_test.cc
@@ -19,8 +19,8 @@
 #include <iostream>
 #include <filesystem>
 
-#include <get_install_prefix_test_shared.h>
-#include <get_install_prefix_test_static.h>
+#include "get_install_prefix_test_shared.h"
+#include "get_install_prefix_test_static.h"
 #include <get_install_prefix_test_cmake_variables.h>
 
 std::string toCanonical(const std::string input_path)

--- a/test/get_install_prefix/get_install_prefix_test.cc
+++ b/test/get_install_prefix/get_install_prefix_test.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <filesystem>
+
+#include <get_install_prefix_test_shared.h>
+#include <get_install_prefix_test_static.h>
+#include <get_install_prefix_test_cmake_variables.h>
+
+std::string toCanonical(const std::string input_path)
+{
+    return std::filesystem::weakly_canonical(std::filesystem::path(input_path)).string();
+}
+
+int main()
+{
+    // Test nominal behaviour
+
+    std::string sharedInstallPrefix = gz::cmake::test::sharedlib::getInstallPrefix();
+    std::string staticInstallPrefix = gz::cmake::test::staticlib::getInstallPrefix();
+
+    std::cerr << "get-install-prefix test:" << std::endl;
+    std::cerr << "sharedInstallPrefix: " << sharedInstallPrefix << std::endl;
+    std::cerr << "CMAKE_BINARY_DIR: " << CMAKE_BINARY_DIR << std::endl;
+    std::cerr << "staticInstallPrefix: " << staticInstallPrefix << std::endl;
+    std::cerr << "CMAKE_INSTALL_PREFIX: " << CMAKE_INSTALL_PREFIX << std::endl;
+
+    if (toCanonical(sharedInstallPrefix) != toCanonical(CMAKE_BINARY_DIR))
+    {
+        std::cerr << "getInstallPrefixShared returned unexpected value, test is failing." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (toCanonical(staticInstallPrefix) != toCanonical(CMAKE_INSTALL_PREFIX))
+    {
+        std::cerr << "getInstallPrefixStatic returned unexpected value, test is failing." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Test behaviour after setting the environment variable to modify the return values (only on Unix so we can use setenv)
+#ifndef _WIN32
+    std::string overrideValue = "test_override_value";
+    int overwrite = 1;
+    setenv("GET_INSTALL_PREFIX_TEST_INSTALL_PREFIX" , overrideValue.c_str(), overwrite);
+    std::string sharedInstallPrefixWithOverride = gz::cmake::test::sharedlib::getInstallPrefix();
+    std::string staticInstallPrefixWithOverride = gz::cmake::test::staticlib::getInstallPrefix();
+
+    std::cerr << "overrideValue: " << overrideValue << std::endl;
+    std::cerr << "sharedInstallPrefixWithOverride: " << sharedInstallPrefixWithOverride << std::endl;
+    std::cerr << "staticInstallPrefixWithOverride: " << staticInstallPrefixWithOverride << std::endl;
+
+    if (overrideValue != sharedInstallPrefixWithOverride)
+    {
+        std::cerr << "getInstallPrefixShared with env variable override returned unexpected value, test is failing." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (overrideValue != sharedInstallPrefixWithOverride)
+    {
+        std::cerr << "getInstallPrefixShared with env variable override returned unexpected value, test is failing." << std::endl;
+        return EXIT_FAILURE;
+    }
+#endif
+
+    return EXIT_SUCCESS;
+}

--- a/test/get_install_prefix/get_install_prefix_test_shared.h
+++ b/test/get_install_prefix/get_install_prefix_test_shared.h
@@ -1,0 +1,13 @@
+namespace gz
+{
+  namespace cmake
+  {
+    namespace test
+    {
+      namespace sharedlib
+      {
+        std::string getInstallPrefix();
+      }
+    }
+  }
+}

--- a/test/get_install_prefix/get_install_prefix_test_static.h
+++ b/test/get_install_prefix/get_install_prefix_test_static.h
@@ -1,0 +1,13 @@
+namespace gz
+{
+  namespace cmake
+  {
+    namespace test
+    {
+      namespace staticlib
+      {
+        std::string getInstallPrefix();
+      }
+    }
+  }
+}


### PR DESCRIPTION
# 🎉 New feature

Closes part of https://github.com/gazebosim/gz-sim/issues/626

## Summary

This PR add functionality in gz-cmake3 that permit to enable binary relocatability in downstream Gazebo libraries.

In particular it:
* Adds the `gz_add_get_install_prefix_impl` CMake function, that can be used in downstream libraries to genate at CMake generation time the implementation of a `gz::<libraryname>::getInstallPrefix()` method. This method permits to compute the installation prefix (i.e. the value of `CMAKE_INSTALL_PREFIX` is a relocatable way, as follows:
  * If the library is compiled as shared, the installation prefix is computed by extracting the location of the shared library on the filesystem using the `dlfcn`'s `dladdr` function, and knowing the relative install location of the shared library.
  * If the library is compiled as static, the implementation falls back to hardcode the `${CMAKE_INSTALL_PREFIX}` used at CMake configuration time in the library.
  * The logic to compute the install prefix in a relocatable is only enabled by setting the `GZ_ENABLE_RELOCATABLE_INSTALL` CMake option to `ON` in the project that calls `gz_add_get_install_prefix_impl` (the default value is `OFF`, as the relocatability logic requires std::filesystem that can create problems due to the mixture of gcc-8 and gcc-9 used in Ubuntu Focal packaging of gz libraries, see https://github.com/gazebosim/gz-cmake/pull/334#issuecomment-1399297156)
  * For both the shared and static case, the value returned by the `gz::<libraryname>::getInstallPrefix()` function can be overriden by defining the `GZ_<uppercaselibraryname>_INSTALL_PREFIX` . This feature has two main use cases:
    * In the cases of static libraries, it can permit to handle the cases in which the files that have been installed with the static library and need to be find via `gz::<libraryname>::getInstallPrefix()` have been moved to a directory different from the `CMAKE_INSTALL_PREFIX` used at CMake configuration time
    * In the case the shared libraries are under tests, we want the `gz::<libraryname>::getInstallPrefix()` to point to the correct installation prefix, not to so location in the build directory in which the expected files are not there. We can achieve this by setting `ENVIRONMENT GZ_<uppercaselibraryname>_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}` for the test suite of a given ignition/gazebo library.

* Adds the `ENVIRONMENT` option in the `gz_build_tests` function, to support the use case described in the previous bullet point.

## Test it

The PR contains test for the `gz_add_get_install_prefix_impl` CMake function that it adds, as long as `GZ_ENABLE_RELOCATABLE_INSTALL` is enable in gz-cmake. Furthermore, the first downstream PR that uses it in an actual Gazebo library is https://github.com/gazebosim/gz-rendering/pull/804 .


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

