### PR TITLE
[Backport Garden] Disable protobuf warnings on protobuf target (#335)

### DIFF
--- a/cmake/FindIgnProtobuf.cmake
+++ b/cmake/FindIgnProtobuf.cmake
@@ -102,5 +102,12 @@ if(${Protobuf_FOUND})
     set_target_properties(protobuf::protoc PROPERTIES
       IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
   endif()
+  
+  # See: https://github.com/osrf/buildfarmer/issues/377
+  if(MSVC)
+    target_compile_options(protobuf::protoc INTERFACE /wd4251)
+    target_compile_options(protobuf::libprotoc INTERFACE /wd4251)
+    target_compile_options(protobuf::libprotobuf INTERFACE /wd4251)
+  endif()
 
 endif()


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

## Summary
Same as the original PR (See #335) for Garden, I forgot it was desirable to get it first here and then port forward it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.