### PR TITLE
Unset package_LIBRARIES cache variable in gz_pkg_check_modules_quiet

### DIFF
--- a/cmake/GzPkgConfig.cmake
+++ b/cmake/GzPkgConfig.cmake
@@ -167,6 +167,11 @@ macro(gz_pkg_check_modules_quiet package signature)
       unset(${package}_FOUND CACHE)
       set(${package}_FOUND TRUE)
 
+      # unset cached libraries variable if not empty before calling
+      # gz_pkg_check_modules_quiet to avoid using incorrect libname
+      # in the find_library call
+      unset(${package}_LIBRARIES CACHE)
+
       # For some reason, pkg_check_modules does not provide complete paths to the
       # libraries it returns, even though find_package is conventionally supposed
       # to provide complete library paths. Having only the library name is harmful

--- a/cmake/GzPkgConfig.cmake
+++ b/cmake/GzPkgConfig.cmake
@@ -124,6 +124,10 @@ macro(gz_pkg_check_modules_quiet package signature)
       set(gz_pkg_check_modules_quiet_arg)
     endif()
 
+    # unset LIBRARIES variable in case it contains full paths already
+    # due to previous calls of this function searching for the same package.
+    unset(${package}_LIBRARIES)
+
     pkg_check_modules(${package}
                       ${gz_pkg_check_modules_quiet_arg}
                       ${gz_pkg_check_modules_no_cmake_environment_path_arg}
@@ -166,11 +170,6 @@ macro(gz_pkg_check_modules_quiet package signature)
       # better solution.
       unset(${package}_FOUND CACHE)
       set(${package}_FOUND TRUE)
-
-      # unset cached libraries variable if not empty before calling
-      # gz_pkg_check_modules_quiet to avoid using incorrect libname
-      # in the find_library call
-      unset(${package}_LIBRARIES CACHE)
 
       # For some reason, pkg_check_modules does not provide complete paths to the
       # libraries it returns, even though find_package is conventionally supposed


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

# 🦟 Bug fix


## Summary

The value of `package_LIBRARIES` var may persist after calling`gz_pkg_check_modules_quiet`, and this causes an issue with subsequent calls to look for the same package. 

The issue happens for me on macOS (cmake version 3.25.2) when building gz-physics from source, see comment https://github.com/gazebosim/gz-sim/issues/1362#issuecomment-1115780880. `TINYXML2` is searched twice, once when cmake tries to find sdformat and again when finding DART. This results in incorrect library paths being set and linked to by DART:

```
ld: library not found for -lTINYXML2_LIBRARY_/opt/homebrew/Cellar/tinyxml2/9.0.0/lib/libtinyxml2.dylib-NOTFOUND
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

