### PR TITLE
Use CONFIG in gz_add_benchmark to avoid Windows collisions

### DIFF
--- a/cmake/GzBenchmark.cmake
+++ b/cmake/GzBenchmark.cmake
@@ -101,7 +101,7 @@ function(gz_add_benchmarks)
 
   file(GENERATE
     OUTPUT
-    "${CMAKE_CURRENT_BINARY_DIR}/benchmark_targets"
+    "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/benchmark_targets"
     CONTENT
     "${BENCHMARK_TARGETS_LIST}")
 
@@ -110,7 +110,7 @@ function(gz_add_benchmarks)
     COMMAND python3 ${GZ_CMAKE_BENCHMARK_DIR}/run_benchmarks.py
       --project-name ${PROJECT_NAME}
       --version-file ${CMAKE_CURRENT_BINARY_DIR}/version_info.json
-      --benchmark-targets ${CMAKE_CURRENT_BINARY_DIR}/benchmark_targets
+      --benchmark-targets ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/benchmark_targets
       --results-root ${CMAKE_BINARY_DIR}/benchmark_results
   )
   add_dependencies(run_benchmarks ${BENCHMARK_TARGETS} version_info_target)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

While testing the new Windows nodes I found that when compiling gz-sim7 for Windows, [CMake was complaining](https://build.osrfoundation.org/job/_test_ign_gazebo-gz-sim7-win/3/consoleFull#764695481aa60f765-a60a-427d-900c-dc128ab22287) about:

```bash
  Evaluation file to be written multiple times with different content.  This
  is generally caused by the content evaluating the configuration type,
  language, or location of object files:

   C:/Jenkins/workspace/_test_ign_gazebo-gz-sim7-win/ws/build/gz-sim7/test/benchmark/benchmark_targets
```

If I'm not wrong, this happens when CMake is evaluating Debug/Release and results in the same path. The PR just adds the configuration to the path to avoid this problem,

I'm not sure why the error does not appear in the current runs of the same stable job but my hypothesis is that the benchmark dependency is being installed in this job and enable the support in gz-sim while the [stable job reports](https://build.osrfoundation.org/job/ign_gazebo-gz-sim7-win/53/consoleText):

```bash
CMake Warning at C:/vcpkg/scripts/buildsystems/vcpkg.cmake:782 (_find_package):
  By not providing "Findbenchmark.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "benchmark", but CMake did not find one.

  Could not find a package configuration file provided by "benchmark" with
  any of the following names:

    benchmarkConfig.cmake
    benchmark-config.cmake

  Add the installation prefix of "benchmark" to CMAKE_PREFIX_PATH or set
  "benchmark_DIR" to a directory containing one of the above files.  If
  "benchmark" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  C:/Jenkins/workspace/ign_gazebo-gz-sim7-win/ws/install/gz-cmake3/share/cmake/gz-cmake3/cmake3/GzBenchmark.cmake:82 (find_package)
  test/benchmark/CMakeLists.txt:10 (gz_add_benchmarks)
```

## Checklist
- [x] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.