### PR TITLE
Add support for symlink install from ament

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,11 @@ install(
   DESTINATION ${gz_modules_install_dir}
   COMPONENT modules)
 
+install(
+  DIRECTORY cmake/symlink_install/
+  DESTINATION ${gz_modules_install_dir}/symlink_install
+  COMPONENT modules)
+
 file(GLOB pkgconfig_templates "cmake/pkgconfig/*.in")
 
 install(

--- a/cmake/GzCMake.cmake
+++ b/cmake/GzCMake.cmake
@@ -31,6 +31,7 @@ include(GzConfigureBuild)
 include(GzImportTarget)
 include(GzPkgConfig)
 include(GzSanitizers)
+include(GzSymlinkInstall)
 
 #============================================================================
 # Native cmake modules

--- a/cmake/GzSymlinkInstall.cmake
+++ b/cmake/GzSymlinkInstall.cmake
@@ -1,0 +1,67 @@
+#.rst
+#
+#===============================================================================
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(GZ_CMAKE_SYMLINK_INSTALL
+  "Replace the CMake install command with a custom implementation using symlinks instead of copying resources"
+  OFF)
+
+if(GZ_CMAKE_SYMLINK_INSTALL)
+  message(STATUS "Override CMake install command with custom implementation "
+    "using symlinks instead of copying resources")
+
+  if(${gz-cmake3_DIR})
+    set(GZ_CMAKE_DIR "${gz-cmake3_DIR}/cmake3")
+  endif()
+
+  include(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_append_install_code.cmake")
+  include(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_directory.cmake")
+  include(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_files.cmake")
+  include(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_programs.cmake")
+  include(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_targets.cmake")
+  include("${GZ_CMAKE_DIR}/symlink_install/install.cmake")
+
+  # create the install script from the template
+  # ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+  set(AMENT_CMAKE_SYMLINK_INSTALL_INSTALL_SCRIPT
+    "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_symlink_install/ament_cmake_symlink_install.cmake")
+  configure_file(
+    "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install.cmake.in"
+    "${AMENT_CMAKE_SYMLINK_INSTALL_INSTALL_SCRIPT}"
+    @ONLY
+  )
+  # register script for being executed at install time
+  install(SCRIPT "${AMENT_CMAKE_SYMLINK_INSTALL_INSTALL_SCRIPT}")
+
+  if(AMENT_CMAKE_UNINSTALL_TARGET)
+    # register uninstall script
+    set(AMENT_CMAKE_SYMLINK_INSTALL_UNINSTALL_SCRIPT
+      "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_symlink_install/ament_cmake_symlink_install_uninstall_script.cmake")
+    configure_file(
+      "${GZ_CMAKE_DIR}/symlink_install/ament_cmake_symlink_install_uninstall_script.cmake.in"
+      "${AMENT_CMAKE_SYMLINK_INSTALL_UNINSTALL_SCRIPT}"
+      @ONLY
+    )
+    ament_cmake_uninstall_target_append_uninstall_code(
+      "include(\"${AMENT_CMAKE_SYMLINK_INSTALL_UNINSTALL_SCRIPT}\")"
+      COMMENTS "uninstall files installed using the symlink install functions")
+  endif()
+endif()

--- a/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+++ b/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
@@ -1,0 +1,311 @@
+# generated from
+# ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+
+# create empty symlink install manifest before starting install step
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/symlink_install_manifest.txt")
+
+#
+# Reimplement CMake install(DIRECTORY) command to use symlinks instead of
+# copying resources.
+#
+# :param cmake_current_source_dir: The CMAKE_CURRENT_SOURCE_DIR when install
+#   was invoked
+# :type cmake_current_source_dir: string
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_directory cmake_current_source_dir)
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION" "DIRECTORY;PATTERN;PATTERN_EXCLUDE" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_cmake_symlink_install_directory() called with "
+      "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # make destination absolute path and ensure that it exists
+  if(NOT IS_ABSOLUTE "${ARG_DESTINATION}")
+    set(ARG_DESTINATION "@CMAKE_INSTALL_PREFIX@/${ARG_DESTINATION}")
+  endif()
+  if(NOT EXISTS "${ARG_DESTINATION}")
+    file(MAKE_DIRECTORY "${ARG_DESTINATION}")
+  endif()
+
+  # default pattern to include
+  if(NOT ARG_PATTERN)
+    set(ARG_PATTERN "*")
+  endif()
+
+  # iterate over directories
+  foreach(dir ${ARG_DIRECTORY})
+    # make dir an absolute path
+    if(NOT IS_ABSOLUTE "${dir}")
+      set(dir "${cmake_current_source_dir}/${dir}")
+    endif()
+
+    if(EXISTS "${dir}")
+      # if directory has no trailing slash
+      # append folder name to destination
+      set(destination "${ARG_DESTINATION}")
+      string(LENGTH "${dir}" length)
+      math(EXPR offset "${length} - 1")
+      string(SUBSTRING "${dir}" ${offset} 1 dir_last_char)
+      if(NOT dir_last_char STREQUAL "/")
+        get_filename_component(destination_name "${dir}" NAME)
+        set(destination "${destination}/${destination_name}")
+      else()
+        # remove trailing slash
+        string(SUBSTRING "${dir}" 0 ${offset} dir)
+      endif()
+
+      # glob recursive files
+      set(relative_files "")
+      foreach(pattern ${ARG_PATTERN})
+        file(
+          GLOB_RECURSE
+          include_files
+          RELATIVE "${dir}"
+          "${dir}/${pattern}"
+        )
+        if(NOT include_files STREQUAL "")
+          list(APPEND relative_files ${include_files})
+        endif()
+      endforeach()
+      foreach(pattern ${ARG_PATTERN_EXCLUDE})
+        file(
+          GLOB_RECURSE
+          exclude_files
+          RELATIVE "${dir}"
+          "${dir}/${pattern}"
+        )
+        if(NOT exclude_files STREQUAL "")
+          list(REMOVE_ITEM relative_files ${exclude_files})
+        endif()
+      endforeach()
+      list(SORT relative_files)
+
+      foreach(relative_file ${relative_files})
+        set(absolute_file "${dir}/${relative_file}")
+        # determine link name for file including destination path
+        set(symlink "${destination}/${relative_file}")
+
+        # ensure that destination exists
+        get_filename_component(symlink_dir "${symlink}" PATH)
+        if(NOT EXISTS "${symlink_dir}")
+          file(MAKE_DIRECTORY "${symlink_dir}")
+        endif()
+
+        _ament_cmake_symlink_install_create_symlink("${absolute_file}" "${symlink}")
+      endforeach()
+    else()
+      if(NOT ARG_OPTIONAL)
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_directory() can't find '${dir}'")
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+#
+# Reimplement CMake install(FILES) command to use symlinks instead of copying
+# resources.
+#
+# :param cmake_current_source_dir: The CMAKE_CURRENT_SOURCE_DIR when install
+#   was invoked
+# :type cmake_current_source_dir: string
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_files cmake_current_source_dir)
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;RENAME" "FILES" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_cmake_symlink_install_files() called with "
+      "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # make destination an absolute path and ensure that it exists
+  if(NOT IS_ABSOLUTE "${ARG_DESTINATION}")
+    set(ARG_DESTINATION "@CMAKE_INSTALL_PREFIX@/${ARG_DESTINATION}")
+  endif()
+  if(NOT EXISTS "${ARG_DESTINATION}")
+    file(MAKE_DIRECTORY "${ARG_DESTINATION}")
+  endif()
+
+  if(ARG_RENAME)
+    list(LENGTH ARG_FILES file_count)
+    if(NOT file_count EQUAL 1)
+    message(FATAL_ERROR "ament_cmake_symlink_install_files() called with "
+      "RENAME argument but not with a single file")
+    endif()
+  endif()
+
+  # iterate over files
+  foreach(file ${ARG_FILES})
+    # make file an absolute path
+    if(NOT IS_ABSOLUTE "${file}")
+      set(file "${cmake_current_source_dir}/${file}")
+    endif()
+
+    if(EXISTS "${file}")
+      # determine link name for file including destination path
+      get_filename_component(filename "${file}" NAME)
+      if(NOT ARG_RENAME)
+        set(symlink "${ARG_DESTINATION}/${filename}")
+      else()
+        set(symlink "${ARG_DESTINATION}/${ARG_RENAME}")
+      endif()
+      _ament_cmake_symlink_install_create_symlink("${file}" "${symlink}")
+    else()
+      if(NOT ARG_OPTIONAL)
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_files() can't find '${file}'")
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+#
+# Reimplement CMake install(PROGRAMS) command to use symlinks instead of copying
+# resources.
+#
+# :param cmake_current_source_dir: The CMAKE_CURRENT_SOURCE_DIR when install
+#   was invoked
+# :type cmake_current_source_dir: string
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_programs cmake_current_source_dir)
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION" "PROGRAMS" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_cmake_symlink_install_programs() called with "
+      "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # make destination an absolute path and ensure that it exists
+  if(NOT IS_ABSOLUTE "${ARG_DESTINATION}")
+    set(ARG_DESTINATION "@CMAKE_INSTALL_PREFIX@/${ARG_DESTINATION}")
+  endif()
+  if(NOT EXISTS "${ARG_DESTINATION}")
+    file(MAKE_DIRECTORY "${ARG_DESTINATION}")
+  endif()
+
+  # iterate over programs
+  foreach(file ${ARG_PROGRAMS})
+    # make file an absolute path
+    if(NOT IS_ABSOLUTE "${file}")
+      set(file "${cmake_current_source_dir}/${file}")
+    endif()
+
+    if(EXISTS "${file}")
+      # determine link name for file including destination path
+      get_filename_component(filename "${file}" NAME)
+      set(symlink "${ARG_DESTINATION}/${filename}")
+      _ament_cmake_symlink_install_create_symlink("${file}" "${symlink}")
+    else()
+      if(NOT ARG_OPTIONAL)
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_programs() can't find '${file}'")
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+#
+# Reimplement CMake install(TARGETS) command to use symlinks instead of copying
+# resources.
+#
+# :param TARGET_FILES: the absolute files, replacing the name of targets passed
+#   in as TARGETS
+# :type TARGET_FILES: list of files
+# :param ARGN: the same arguments as the CMake install command except that
+#   keywords identifying the kind of type and the DESTINATION keyword must be
+#   joined with an underscore, e.g. ARCHIVE_DESTINATION.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_targets)
+  cmake_parse_arguments(ARG "OPTIONAL" "ARCHIVE_DESTINATION;DESTINATION;LIBRARY_DESTINATION;RUNTIME_DESTINATION"
+    "TARGETS;TARGET_FILES" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_cmake_symlink_install_targets() called with "
+      "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # iterate over target files
+  foreach(file ${ARG_TARGET_FILES})
+    if(NOT IS_ABSOLUTE "${file}")
+      message(FATAL_ERROR "ament_cmake_symlink_install_targets() target file "
+        "'${file}' must be an absolute path")
+    endif()
+
+    # determine destination of file based on extension
+    set(destination "")
+    get_filename_component(fileext "${file}" EXT)
+    if(fileext STREQUAL ".a" OR fileext STREQUAL ".lib")
+      set(destination "${ARG_ARCHIVE_DESTINATION}")
+    elseif(fileext STREQUAL ".dylib" OR fileext MATCHES "\\.so(\\.[0-9]+)?(\\.[0-9]+)?(\\.[0-9]+)?$")
+      set(destination "${ARG_LIBRARY_DESTINATION}")
+    elseif(fileext STREQUAL "" OR fileext STREQUAL ".dll" OR fileext STREQUAL ".exe")
+      set(destination "${ARG_RUNTIME_DESTINATION}")
+    endif()
+    if(destination STREQUAL "")
+      set(destination "${ARG_DESTINATION}")
+    endif()
+
+    # make destination an absolute path and ensure that it exists
+    if(NOT IS_ABSOLUTE "${destination}")
+      set(destination "@CMAKE_INSTALL_PREFIX@/${destination}")
+    endif()
+    if(NOT EXISTS "${destination}")
+      file(MAKE_DIRECTORY "${destination}")
+    endif()
+
+    if(EXISTS "${file}")
+      # determine link name for file including destination path
+      get_filename_component(filename "${file}" NAME)
+      set(symlink "${destination}/${filename}")
+      _ament_cmake_symlink_install_create_symlink("${file}" "${symlink}")
+    else()
+      if(NOT ARG_OPTIONAL)
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_targets() can't find '${file}'")
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+function(_ament_cmake_symlink_install_create_symlink absolute_file symlink)
+  # register symlink for being removed during install step
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/symlink_install_manifest.txt"
+    "${symlink}\n")
+
+  # avoid any work if correct symlink is already in place
+  if(EXISTS "${symlink}" AND IS_SYMLINK "${symlink}")
+    get_filename_component(destination "${symlink}" REALPATH)
+    get_filename_component(real_absolute_file "${absolute_file}" REALPATH)
+    if(destination STREQUAL real_absolute_file)
+      message(STATUS "Up-to-date symlink: ${symlink}")
+      return()
+    endif()
+  endif()
+
+  message(STATUS "Symlinking: ${symlink}")
+  if(EXISTS "${symlink}" OR IS_SYMLINK "${symlink}")
+    file(REMOVE "${symlink}")
+  endif()
+
+  execute_process(
+    COMMAND "@CMAKE_COMMAND@" "-E" "create_symlink"
+      "${absolute_file}"
+      "${symlink}"
+  )
+  # the CMake command does not provide a return code so check manually
+  if(NOT EXISTS "${symlink}" OR NOT IS_SYMLINK "${symlink}")
+    get_filename_component(destination "${symlink}" REALPATH)
+    message(FATAL_ERROR
+      "Could not create symlink '${symlink}' pointing to '${absolute_file}'")
+  endif()
+endfunction()
+
+# end of template
+
+message(STATUS "Execute custom install script")
+
+# begin of custom install code

--- a/cmake/symlink_install/ament_cmake_symlink_install_append_install_code.cmake
+++ b/cmake/symlink_install/ament_cmake_symlink_install_append_install_code.cmake
@@ -1,0 +1,34 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Register a CMake script for execution at install time.
+#
+# :param ARGN: the list of CMake code lines
+# :type ARGN: list of strings
+# :param COMMENTS: an optional list of comments
+# :type COMMENTS: list of strings
+#
+function(ament_cmake_symlink_install_append_install_code)
+  cmake_parse_arguments(ARG "" "" "COMMENTS" ${ARGN})
+
+  # append code to install script
+  if(ARG_COMMENTS)
+    file(APPEND "${AMENT_CMAKE_SYMLINK_INSTALL_INSTALL_SCRIPT}"
+      "\n# ${ARG_COMMENTS}\n")
+  endif()
+  foreach(code ${ARG_UNPARSED_ARGUMENTS})
+    file(APPEND "${AMENT_CMAKE_SYMLINK_INSTALL_INSTALL_SCRIPT}" "${code}\n")
+  endforeach()
+endfunction()

--- a/cmake/symlink_install/ament_cmake_symlink_install_directory.cmake
+++ b/cmake/symlink_install/ament_cmake_symlink_install_directory.cmake
@@ -1,0 +1,79 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Reimplement CMake install(DIRECTORY) command to use symlinks instead of
+# copying resources.
+#
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_directory directory_keyword)
+  if(NOT directory_keyword STREQUAL "DIRECTORY")
+    message(FATAL_ERROR "ament_cmake_symlink_install_directory() first "
+      "argument must be 'DIRECTORY', not '${directory_keyword}'")
+  endif()
+
+  set(unsupported_keywords
+    "FILE_PERMISSIONS"
+    "DIRECTORY_PERMISSIONS"
+    "USE_SOURCE_PERMISSIONS"
+    "CONFIGURATIONS"
+    "COMPONENT"
+    "FILES_MATCHING"
+    "REGEX"
+    "PERMISSIONS"
+  )
+  foreach(unsupported_keyword ${unsupported_keywords})
+    list(FIND ARGN "${unsupported_keyword}" index)
+    if(NOT index EQUAL -1)
+      # fall back to CMake install() command
+      # if the arguments can't be handled
+      _install(DIRECTORY ${ARGN})
+      break()
+    endif()
+  endforeach()
+
+  if(index EQUAL -1)
+    # merge 'PATTERN "xxx" EXCLUDE' arguments to 'PATTERN_EXCLUDE "xxx"'
+    set(argn ${ARGN})
+    list(LENGTH argn length)
+    set(i 0)
+    while(i LESS length)
+      list(GET argn ${i} arg)
+      if(arg STREQUAL "PATTERN")
+        math(EXPR j "${i} + 2")
+        if(j LESS length)
+          list(GET argn ${j} arg)
+          if(arg STREQUAL "EXCLUDE")
+            # replace "PATTERN" with "PATTERN_EXCLUDE"
+            list(REMOVE_AT argn ${i})
+            list(INSERT argn ${i} "PATTERN_EXCLUDE")
+            # remove "EXCLUDE"
+            list(REMOVE_AT argn ${j})
+            # get changed length
+            list(LENGTH argn length)
+          endif()
+        endif()
+      endif()
+      math(EXPR i "${i} + 1")
+    endwhile()
+
+    string(REPLACE ";" "\" \"" argn_quoted "\"${argn}\"")
+    ament_cmake_symlink_install_append_install_code(
+      "ament_cmake_symlink_install_directory(\"${CMAKE_CURRENT_SOURCE_DIR}\" DIRECTORY ${argn_quoted})"
+      COMMENTS "install(DIRECTORY ${argn_quoted})"
+    )
+  endif()
+endfunction()

--- a/cmake/symlink_install/ament_cmake_symlink_install_files.cmake
+++ b/cmake/symlink_install/ament_cmake_symlink_install_files.cmake
@@ -1,0 +1,50 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Reimplement CMake install(FILES) command to use symlinks instead of copying
+# resources.
+#
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_files files_keyword)
+  if(NOT files_keyword STREQUAL "FILES")
+    message(FATAL_ERROR "ament_cmake_symlink_install_files() first argument "
+      "must be 'FILES', not '${files_keyword}'")
+  endif()
+
+  set(unsupported_keywords
+    "PERMISSIONS"
+    "CONFIGURATIONS"
+    "COMPONENT"
+  )
+  foreach(unsupported_keyword ${unsupported_keywords})
+    list(FIND ARGN "${unsupported_keyword}" index)
+    if(NOT index EQUAL -1)
+      # fall back to CMake install() command
+      # if the arguments can't be handled
+      _install(FILES ${ARGN})
+      break()
+    endif()
+  endforeach()
+
+  if(index EQUAL -1)
+    string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
+    ament_cmake_symlink_install_append_install_code(
+      "ament_cmake_symlink_install_files(\"${CMAKE_CURRENT_SOURCE_DIR}\" FILES ${argn_quoted})"
+      COMMENTS "install(FILES ${argn_quoted})"
+    )
+  endif()
+endfunction()

--- a/cmake/symlink_install/ament_cmake_symlink_install_programs.cmake
+++ b/cmake/symlink_install/ament_cmake_symlink_install_programs.cmake
@@ -1,0 +1,51 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Reimplement CMake install(PROGRAMS) command to use symlinks instead of copying
+# resources.
+#
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_programs programs_keyword)
+  if(NOT programs_keyword STREQUAL "PROGRAMS")
+    message(FATAL_ERROR "ament_cmake_symlink_install_programs() first argument "
+      "must be 'PROGRAMS', not '${programs_keyword}'")
+  endif()
+
+  set(unsupported_keywords
+    "PERMISSIONS"
+    "CONFIGURATIONS"
+    "COMPONENT"
+    "RENAME"
+  )
+  foreach(unsupported_keyword ${unsupported_keywords})
+    list(FIND ARGN "${unsupported_keyword}" index)
+    if(NOT index EQUAL -1)
+      # fall back to CMake install() command
+      # if the arguments can't be handled
+      _install(PROGRAMS ${ARGN})
+      break()
+    endif()
+  endforeach()
+
+  if(index EQUAL -1)
+    string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
+    ament_cmake_symlink_install_append_install_code(
+      "ament_cmake_symlink_install_programs(\"${CMAKE_CURRENT_SOURCE_DIR}\" PROGRAMS ${argn_quoted})"
+      COMMENTS "install(PROGRAMS ${argn_quoted})"
+    )
+  endif()
+endfunction()

--- a/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
+++ b/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
@@ -1,0 +1,116 @@
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(__AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX "0"
+  CACHE INTERNAL "Index for unique symlink install targets")
+
+#
+# Reimplement CMake install(TARGETS) command to use symlinks instead of copying
+# resources.
+#
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(ament_cmake_symlink_install_targets)
+  if(NOT "${ARGV0}" STREQUAL "TARGETS")
+    message(FATAL_ERROR "ament_cmake_symlink_install_targets() first argument "
+      "must be 'TARGETS', not '${ARGV0}'")
+  endif()
+
+  set(unsupported_keywords
+    "EXPORT"
+    "FRAMEWORK"
+    "BUNDLE"
+    "PRIVATE_HEADER"
+    "PUBLIC_HEADER"
+    "RESOURCE"
+    "INCLUDES"
+    "PERMISSIONS"
+    "CONFIGURATIONS"
+    "COMPONENT"
+    "NAMELINK_ONLY"
+    "NAMELINK_SKIP"
+  )
+  foreach(unsupported_keyword ${unsupported_keywords})
+    list(FIND ARGN "${unsupported_keyword}" index)
+    if(NOT index EQUAL -1)
+      # fall back to CMake install() command
+      # if the arguments can't be handled
+      _install(${ARGN})
+      break()
+    endif()
+  endforeach()
+
+  if(index EQUAL -1)
+    cmake_parse_arguments(ARG "ARCHIVE;LIBRARY;RUNTIME;OPTIONAL" "DESTINATION"
+      "TARGETS" ${ARGN})
+    if(ARG_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "ament_cmake_symlink_install_targets() called with "
+        "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+
+    # convert target names into absolute files
+    set(target_files "")
+    foreach(target ${ARG_TARGETS})
+      if(NOT TARGET ${target})
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_targets() '${target}' is not a target")
+      endif()
+      get_target_property(is_imported "${target}" IMPORTED)
+      if(is_imported)
+        message(FATAL_ERROR "ament_cmake_symlink_install_targets() "
+          "'${target}' is an imported target")
+      endif()
+      list(APPEND target_files "$<TARGET_FILE:${target}>")
+      get_target_property(target_type "${target}" TYPE)
+      if(WIN32 AND "${target_type}" STREQUAL "SHARED_LIBRARY")
+        list(APPEND target_files "$<TARGET_LINKER_FILE:${target}>")
+      endif()
+      if("${target_type}" STREQUAL "INTERFACE_LIBRARY")
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_targets() '${target}' is an interface "
+          "library - there's nothing to symlink install. Perhaps you forgot "
+          "to add EXPORT or INCLUDES DESTINATION?")
+      endif()
+    endforeach()
+
+    string(REPLACE ";" "\" \"" target_files_quoted
+      "\"TARGET_FILES;${target_files}\"")
+    string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
+
+    # join destination keyword with kind of target (e.g. ARCHIVE)
+    # to simplify parsing in the next CMake function
+    string(REPLACE "\"ARCHIVE\" \"DESTINATION\"" "\"ARCHIVE_DESTINATION\"" argn_quoted "${argn_quoted}")
+    string(REPLACE "\"LIBRARY\" \"DESTINATION\"" "\"LIBRARY_DESTINATION\"" argn_quoted "${argn_quoted}")
+    string(REPLACE "\"RUNTIME\" \"DESTINATION\"" "\"RUNTIME_DESTINATION\"" argn_quoted "${argn_quoted}")
+
+    # generate unique files
+    set(generated_file_base
+      "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_symlink_install_targets_${__AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX}")
+    set(generated_file_generator_suffix "${generated_file_base}_$<CONFIG>.cmake")
+    set(generated_file_variable_suffix "${generated_file_base}_\${CMAKE_INSTALL_CONFIG_NAME}.cmake")
+    math(EXPR __AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX
+      "${__AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX} + 1")
+    set(__AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX "${__AMENT_CMAKE_SYMLINK_INSTALL_TARGETS_INDEX}"
+      CACHE INTERNAL "Index for unique symlink install targets")
+
+    file(GENERATE OUTPUT "${generated_file_generator_suffix}"
+      CONTENT
+      "ament_cmake_symlink_install_targets(${target_files_quoted} ${argn_quoted})\n")
+    ament_cmake_symlink_install_append_install_code(
+      "include(\"${generated_file_variable_suffix}\")"
+      COMMENTS "install(${argn_quoted})"
+    )
+  endif()
+endfunction()

--- a/cmake/symlink_install/ament_cmake_symlink_install_uninstall_script.cmake.in
+++ b/cmake/symlink_install/ament_cmake_symlink_install_uninstall_script.cmake.in
@@ -1,0 +1,23 @@
+# generated from
+# ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_uninstall_script.cmake.in
+
+set(install_manifest "@CMAKE_CURRENT_BINARY_DIR@/symlink_install_manifest.txt")
+if(NOT EXISTS "${install_manifest}")
+  message(FATAL_ERROR "Cannot find symlink install manifest: ${install_manifest}")
+endif()
+
+file(READ "${install_manifest}" installed_files)
+string(REGEX REPLACE "\n" ";" installed_files "${installed_files}")
+foreach(installed_file ${installed_files})
+  if(EXISTS "${installed_file}" OR IS_SYMLINK "${installed_file}")
+    message(STATUS "Uninstalling: ${installed_file}")
+    file(REMOVE "${installed_file}")
+    if(EXISTS "${installed_file}" OR IS_SYMLINK "${installed_file}")
+      message(FATAL_ERROR "Failed to remove '${installed_file}'")
+    endif()
+
+    # remove empty parent folders
+    get_filename_component(parent_path "${installed_file}" PATH)
+    ament_cmake_uninstall_target_remove_empty_directories("${parent_path}")
+  endif()
+endforeach()

--- a/cmake/symlink_install/install.cmake
+++ b/cmake/symlink_install/install.cmake
@@ -1,0 +1,44 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Overwrite CMake install command to use symlinks instead of copying resources.
+#
+# :param signature: one of the CMake keywords used to choose between the
+#   different install signatures, e.g. DIRECTORY, FILES, PROGRAMS, TARGETS.
+# :type signature: string
+# :param ARGN: the same arguments as the CMake install command.
+# :type ARGN: various
+#
+function(install signature)
+  string(TOUPPER "${signature}" signature)
+
+  if(signature STREQUAL "DIRECTORY")
+    ament_cmake_symlink_install_directory(DIRECTORY ${ARGN})
+    return()
+  elseif(signature STREQUAL "FILES")
+    ament_cmake_symlink_install_files(FILES ${ARGN})
+    return()
+  elseif(signature STREQUAL "PROGRAMS")
+    ament_cmake_symlink_install_programs(PROGRAMS ${ARGN})
+    return()
+  elseif(signature STREQUAL "TARGETS")
+    ament_cmake_symlink_install_targets(TARGETS ${ARGN})
+    return()
+  endif()
+
+  # fall back to CMake install() command
+  # if the arguments haven't been handled before
+  _install(${signature} ${ARGN})
+endfunction()


### PR DESCRIPTION
# 🎉 New feature

Closes #288 

## Summary

Adds support for symlink-install where supported.  

Unfortunately, this is less effective than ROS because we use `COMPONENT` pretty heavily, which causes this to go to the default installation mechanism in CMake.  I'm going to keep this in draft until I can take a look at that.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

