### PR TITLE
Updates to PR 344: split GzUtils

### DIFF
--- a/cmake/GzAddComponent.cmake
+++ b/cmake/GzAddComponent.cmake
@@ -20,9 +20,9 @@
 #                   [INDEPENDENT_FROM_PROJECT_LIB]
 #                   [PRIVATELY_DEPENDS_ON_PROJECT_LIB]
 #                   [INTERFACE_DEPENDS_ON_PROJECT_LIB]
-#                   [CXX_STANDARD <10|14|17>]
-#                   [PRIVATE_CXX_STANDARD <10|14|17>]
-#                   [INTERFACE_CXX_STANDARD <10|14|17>])
+#                   [CXX_STANDARD <11|14|17>]
+#                   [PRIVATE_CXX_STANDARD <11|14|17>]
+#                   [INTERFACE_CXX_STANDARD <11|14|17>])
 #
 # This function will produce a "component" library for your project. This is the
 # recommended way to produce plugins or library modules.
@@ -89,7 +89,7 @@ function(ign_add_component component_name)
 endfunction()
 function(gz_add_component component_name)
 
-  # Deprecated, remove skip parsing logic in version 3
+  # Deprecated, remove skip parsing logic in version 4
   if (NOT gz_add_component_skip_parsing)
     #------------------------------------
     # Define the expected arguments

--- a/cmake/GzBuildTests.cmake
+++ b/cmake/GzBuildTests.cmake
@@ -16,7 +16,8 @@
 #                 SOURCES <sources>
 #                 [LIB_DEPS <library_dependencies>]
 #                 [INCLUDE_DIRS <include_dependencies>]
-#                 [TEST_LIST <output_var>])
+#                 [TEST_LIST <output_var>]
+#                 [ENVIRONMENT <environment>])
 #
 # Build tests for a Gazebo project. Arguments are as follows:
 #
@@ -41,6 +42,8 @@
 #                      will also skip the step of copying the runtime library
 #                      into your executable's directory.
 #
+# ENVIRONMENT: Optional. Used to set the ENVIRONMENT property of the tests.
+#
 macro(ign_build_tests)
   message(WARNING "ign_build_tests is deprecated, use gz_build_tests instead.")
 
@@ -60,7 +63,7 @@ macro(gz_build_tests)
     # Define the expected arguments
     set(options SOURCE EXCLUDE_PROJECT_LIB) # NOTE: DO NOT USE "SOURCE", we're adding it here to catch typos
     set(oneValueArgs TYPE TEST_LIST)
-    set(multiValueArgs SOURCES LIB_DEPS INCLUDE_DIRS)
+    set(multiValueArgs SOURCES LIB_DEPS INCLUDE_DIRS ENVIRONMENT)
 
     #------------------------------------
     # Parse the arguments
@@ -131,6 +134,10 @@ macro(gz_build_tests)
 
       add_test(NAME ${target_name} COMMAND
         ${target_name} --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
+
+      if(gz_build_tests_ENVIRONMENT)
+        set_property(TEST ${target_name} PROPERTY ENVIRONMENT ${gz_build_tests_ENVIRONMENT})
+      endif()
 
       if(UNIX)
         # gtest requies pthread when compiled on a Unix machine


### PR DESCRIPTION
I was reviewing the changes in #344 using `meld` and noticed a few differences between `GzUtils.cmake` as of 811ba021068220567e4f3166263fb0dae652f972 and the files in this PR, so I've applied the appropriate fixes here. I'll be ready to approve #344 after this goes in.