### PR TITLE
Prepare for gz-cmake2 2.17.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.16.0)
+project(ignition-cmake2 VERSION 2.17.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
     * [Pull request #338](https://github.com/gazebosim/ign-cmake/pull/338)
 
 1. Disable protobuf warnings on protobuf target (#335)
-    * [Pull request #335) (#336](https://github.com/gazebosim/ign-cmake/pull/335) (#336)
+    * [Pull request #335](https://github.com/gazebosim/ign-cmake/pull/335)
 
 1. Fix FindAVDEVICE.cmake in case without pkg-config installed with ffmpeg >= 5.1
     * [Pull request #330](https://github.com/gazebosim/ign-cmake/pull/330)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,18 @@
-## Ignition CMake 2.x
+## Gazebo CMake 2.x
+
+### Gazebo CMake 2.17.0 (2023-05-19)
+
+1. Use CONFIG in gz_add_benchmark to avoid Windows collisions
+    * [Pull request #341](https://github.com/gazebosim/ign-cmake/pull/341)
+
+1. LICENSE: add Apache 2.0 license text
+    * [Pull request #338](https://github.com/gazebosim/ign-cmake/pull/338)
+
+1. Disable protobuf warnings on protobuf target (#335)
+    * [Pull request #335) (#336](https://github.com/gazebosim/ign-cmake/pull/335) (#336)
+
+1. Fix FindAVDEVICE.cmake in case without pkg-config installed with ffmpeg >= 5.1
+    * [Pull request #330](https://github.com/gazebosim/ign-cmake/pull/330)
 
 ### Ignition CMake 2.16.0 (2022-10-08)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.17.0 release.

Comparison to 2.16.0: https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.16.0...jrivero/gz_cmake_2_17_0?expand=1

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.