### PR TITLE
GzSetCompilerFlags: Fix detection of clang-cl

### DIFF
--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -38,9 +38,13 @@ macro(_gz_set_compiler_flags)
     _gz_setup_apple()
   endif()
 
-  # Check if we are compiling with Clang and cache it
+  # Check if we are compiling with Clang with GNU-like flags and cache it
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CLANG true)
+    if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+      set(CLANG false)
+    else()
+      set(CLANG true)
+    endif()
   endif()
 
   # Check if we are compiling with GCC and cache it


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation of gz-* projects with [`clang-cl`](https://clang.llvm.org/docs/UsersManual.html#clang-cl). 

## Summary

On Windows, there are two drivers available for the clang compiler:
* `clang`, that takes in input GCC-style compiler flags
* `clang-cl`, that takes in input MSVC-style compiler flags

When `clang-cl` is used, it does not make sense to pass to it GCC-style compiler flags. Befor this PR, GCC-style compiler flags were passed to clang-cl, that due to some combination with the existing MSVC flags resulted in the wrong C++ standard version be used when compiling the project, creating an endless list of warnings like:
~~~
C:\src\gz-math\include\gz/math/Vector2.hh(34,5): warning: inline namespaces are incompatible with C++98 [-Wc++98-compat]
    inline namespace GZ_MATH_VERSION_NAMESPACE {
    ^
C:\src\gz-math\include\gz/math/Vector2.hh(51,15): warning: 'constexpr' specifier is incompatible with C++98 [-Wc++98-compat]
      public: constexpr Vector2()
              ^
C:\src\gz-math\include\gz/math/Vector2.hh(59,15): warning: 'constexpr' specifier is incompatible with C++98 [-Wc++98-compat]
      public: constexpr Vector2(const T &_x, const T &_y)
              ^
C:\src\gz-math\include\gz/math/Vector2.hh(66,47): warning: defaulted function definitions are incompatible with C++98 [-Wc++98-compat]
      public: Vector2(const Vector2<T> &_v) = default;
                                              ^
C:\src\gz-math\include\gz/math/Vector2.hh(69,28): warning: defaulted function definitions are incompatible with C++98 [-Wc++98-compat]
      public: ~Vector2() = default;
                           ^
C:\src\gz-math\include\gz/math/Vector2.hh(227,55): warning: defaulted function definitions are incompatible with C++98 [-Wc++98-compat]
      public: Vector2 &operator=(const Vector2 &_v) = default;
                                                      ^
C:\src\gz-math\include\gz/math/Vector2.hh(52,13): warning: generalized initializer lists are incompatible with C++98 [-Wc++98-compat]
      : data{0, 0}
            ^
C:\src\gz-math\include\gz/math/Vector2.hh(60,13): warning: generalized initializer lists are incompatible with C++98 [-Wc++98-compat]
      : data{_x, _y}
~~~

This PR fixes this by only adding GCC-style compiler flags if `clang` is used, and not adding them if `clang-cl` is using. Strictly speaking the variable used to check if `clang-cl` is used is `CMAKE_CXX_COMPILER_FRONTEND_VARIANT`, that was only introduced in CMake 3.14 while gz-cmake3 supprots CMake 3.2 . However, if that code is evaluted in CMake <= 3.13, the variable `CMAKE_CXX_COMPILER_FRONTEND_VARIANT` will be empty and the check:
~~~
CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"
~~~
will be false.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

