### PR TITLE
Check for empty variables before performing REPLACE

### DIFF
--- a/cmake/GzBuildExamples.cmake
+++ b/cmake/GzBuildExamples.cmake
@@ -51,9 +51,15 @@ macro(gz_build_examples)
 
   set(gz_build_examples_CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
 
-  message(STATUS ${gz_build_examples_CMAKE_PREFIX_PATH})
-  string(REPLACE ":" ";" gz_build_examples_CMAKE_PREFIX_PATH ${gz_build_examples_CMAKE_PREFIX_PATH})
-  list(APPEND gz_build_examples_CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
+  if (${gz_build_examples_CMAKE_PREFIX_PATH})
+    # Replace colons from environment variable with semicolon cmake list delimiter
+    # Only perform if string has contents, otherwise cmake will complain about REPLACE command
+    string(REPLACE ":" ";" gz_build_examples_CMAKE_PREFIX_PATH ${gz_build_examples_CMAKE_PREFIX_PATH})
+  endif()
+
+  if (${CMAKE_INSTALL_PREFIX})
+    list(APPEND gz_build_examples_CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
+  endif()
 
   add_test(
     NAME EXAMPLES_Configure_TEST

--- a/cmake/GzBuildExamples.cmake
+++ b/cmake/GzBuildExamples.cmake
@@ -1,0 +1,79 @@
+# Copyright (C) 2023 Open Source Robotics Foundation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#################################################
+# gz_build_examples(
+#     SOURCE_DIR <source_dir>
+#     BINARY_DIR <binary_dir>
+#
+# Build examples for a Gazebo project.
+# Requires a CMakeLists.txt file to be in SOURCE_DIR that acts
+# as a top level project.
+#
+# This generates two test targets
+# * EXAMPLES_Configure_TEST - Equivalent of calling "cmake .." on
+#                             the examples directory
+#
+# * EXAMPLES_Build_TEST - Equivalent of calling "make" on the
+#                         examples directory
+#
+# These tests are run during "make test" or can be run specifically
+# via "ctest -R EXAMPLES_ -V"
+#
+# Arguments are as follows:
+#
+# SOURCE_DIR: Required. Path to the examples folder.
+#             For example ${CMAKE_CURRENT_SOURCE_DIR}/examples
+#
+# BINARY_DIR: Required. Path to the output binary folder
+#             For example ${CMAKE_CURRENT_BINARY_DIR}/examples
+#
+macro(gz_build_examples)
+  #------------------------------------
+  # Define the expected arguments
+  set(options)
+  set(oneValueArgs SOURCE_DIR BINARY_DIR)
+
+  #------------------------------------
+  # Parse the arguments
+  _gz_cmake_parse_arguments(gz_build_examples "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(gz_build_examples_CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+
+  message(STATUS ${gz_build_examples_CMAKE_PREFIX_PATH})
+  string(REPLACE ":" ";" gz_build_examples_CMAKE_PREFIX_PATH ${gz_build_examples_CMAKE_PREFIX_PATH})
+  list(APPEND gz_build_examples_CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
+
+  add_test(
+    NAME EXAMPLES_Configure_TEST
+    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR}
+                             --no-warn-unused-cli
+                             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                             "-DCMAKE_PREFIX_PATH=${gz_build_examples_CMAKE_PREFIX_PATH}"
+                             -S ${gz_build_examples_SOURCE_DIR}
+                             -B ${gz_build_examples_BINARY_DIR}
+  )
+
+  add_test(
+    NAME EXAMPLES_Build_TEST
+    COMMAND ${CMAKE_COMMAND} --build ${gz_build_examples_BINARY_DIR}
+                             --config $<CONFIG>
+  )
+  set_tests_properties(EXAMPLES_Build_TEST
+    PROPERTIES DEPENDS "EXAMPLES_Configure_TEST")
+endmacro()

--- a/cmake/GzUtils.cmake
+++ b/cmake/GzUtils.cmake
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 include(GzAddComponent)
+include(GzBuildExamples)
 include(GzBuildExecutables)
 include(GzBuildTests)
 include(GzCmakeLogging)
@@ -289,71 +290,6 @@ macro(_gz_add_library_or_component)
     RUNTIME DESTINATION ${GZ_BIN_INSTALL_DIR}
     COMPONENT libraries)
 
-endmacro()
-
-
-#################################################
-# gz_build_examples(
-#     SOURCE_DIR <source_dir>
-#     BINARY_DIR <binary_dir>
-#
-# Build examples for a Gazebo project.
-# Requires a CMakeLists.txt file to be in SOURCE_DIR that acts
-# as a top level project.
-#
-# This generates two test targets
-# * EXAMPLES_Configure_TEST - Equivalent of calling "cmake .." on
-#                             the examples directory
-#
-# * EXAMPLES_Build_TEST - Equivalent of calling "make" on the
-#                         examples directory
-#
-# These tests are run during "make test" or can be run specifically
-# via "ctest -R EXAMPLES_ -V"
-#
-# Arguments are as follows:
-#
-# SOURCE_DIR: Required. Path to the examples folder.
-#             For example ${CMAKE_CURRENT_SOURCE_DIR}/examples
-#
-# BINARY_DIR: Required. Path to the output binary folder
-#             For example ${CMAKE_CURRENT_BINARY_DIR}/examples
-#
-macro(gz_build_examples)
-  #------------------------------------
-  # Define the expected arguments
-  set(options)
-  set(oneValueArgs SOURCE_DIR BINARY_DIR)
-
-  #------------------------------------
-  # Parse the arguments
-  _gz_cmake_parse_arguments(gz_build_examples "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-  set(gz_build_examples_CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
-  string(REPLACE ":" ";" gz_build_examples_CMAKE_PREFIX_PATH ${gz_build_examples_CMAKE_PREFIX_PATH})
-  list(APPEND gz_build_examples_CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
-
-  add_test(
-    NAME EXAMPLES_Configure_TEST
-    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR}
-                             --no-warn-unused-cli
-                             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-                             "-DCMAKE_PREFIX_PATH=${gz_build_examples_CMAKE_PREFIX_PATH}"
-                             -S ${gz_build_examples_SOURCE_DIR}
-                             -B ${gz_build_examples_BINARY_DIR}
-  )
-
-  add_test(
-    NAME EXAMPLES_Build_TEST
-    COMMAND ${CMAKE_COMMAND} --build ${gz_build_examples_BINARY_DIR}
-                             --config $<CONFIG>
-  )
-  set_tests_properties(EXAMPLES_Build_TEST
-    PROPERTIES DEPENDS "EXAMPLES_Configure_TEST")
 endmacro()
 
 #################################################


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

If the CMAKE_PREFIX_PATH environment variable was empty, the string replace command could fail with (from https://github.com/gazebosim/gz-math/actions/runs/5057393702/jobs/9154388249?pr=482)

```
  CMake Error at /usr/share/cmake/gz-cmake3/cmake3/GzUtils.cmake:333 (string):
    string sub-command REPLACE requires at least four arguments.
  Call Stack (most recent call first):
    CMakeLists.txt:153 (gz_build_examples)
```

This moves the function into it's own file (to make it align with rest of the work from #344), and then checks correctly for empty variables before performing the replacement.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.