### PR TITLE
Fix incorrect if comparison in build_examples

### DIFF
--- a/cmake/GzBuildExamples.cmake
+++ b/cmake/GzBuildExamples.cmake
@@ -51,13 +51,13 @@ macro(gz_build_examples)
 
   set(gz_build_examples_CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
 
-  if (${gz_build_examples_CMAKE_PREFIX_PATH})
+  if (gz_build_examples_CMAKE_PREFIX_PATH)
     # Replace colons from environment variable with semicolon cmake list delimiter
     # Only perform if string has contents, otherwise cmake will complain about REPLACE command
     string(REPLACE ":" ";" gz_build_examples_CMAKE_PREFIX_PATH ${gz_build_examples_CMAKE_PREFIX_PATH})
   endif()
 
-  if (${CMAKE_INSTALL_PREFIX})
+  if (CMAKE_INSTALL_PREFIX)
     list(APPEND gz_build_examples_CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
   endif()
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Introduced in https://github.com/gazebosim/gz-cmake/pull/354

While I tested this with my local Windows machine, the buildfarm seems to be slightly different yielding an error. 

```
CMake Error at C:/J/workspace/ign_common-pr-win/ws/install/gz-cmake3/share/cmake/gz-cmake3/cmake3/GzBuildExamples.cmake:54 (if):
  if given arguments:

    "C:\\J\\workspace\\ign_common-pr-win\\ws\\install\\gz-math7" "C:\\J\\workspace\\ign_common-pr-win\\ws\\install\\gz-utils2" "C:\\J\\workspace\\ign_common-pr-win\\ws\\install\\gz-cmake3"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:164 (gz_build_examples)
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

