### PR TITLE
Fix usage of FindGzOGRE2 on Windows when pkg-config is available

### DIFF
--- a/cmake/FindGzOGRE2.cmake
+++ b/cmake/FindGzOGRE2.cmake
@@ -26,7 +26,6 @@
 # to be set before calling find_package:
 #
 #  GZ_OGRE2_PROJECT_NAME    Possible values: OGRE2 (default) or OGRE-Next
-#                            (Only on UNIX, not in use for Windows)
 #                            Specify the project name used in the packaging.
 #                            It will impact directly in the name of the
 #                            CMake/pkg-config modules being used.
@@ -43,8 +42,6 @@
 #  OGRE2_RESOURCE_PATH      Path to ogre plugins directory
 #  GzOGRE2::GzOGRE2       Imported target for OGRE2
 #
-# On Windows, we assume that all the OGRE* defines are passed in manually
-# to CMake.
 #
 # Supports finding the following OGRE2 components: HlmsPbs, HlmsUnlit, Overlay,
 #  PlanarReflections
@@ -147,7 +144,8 @@ macro(get_preprocessor_entry CONTENTS KEYWORD VARIABLE)
   endif ()
 endmacro()
 
-if (NOT WIN32)
+find_package(PkgConfig QUIET)
+if (PkgConfig_FOUND)
   set(PKG_CONFIG_PATH_ORIGINAL $ENV{PKG_CONFIG_PATH})
   foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next")
     message(STATUS "Looking for OGRE using the name: ${GZ_OGRE2_PROJECT_NAME}")
@@ -393,7 +391,7 @@ if (NOT WIN32)
   # because gz_pkg_check_modules does not work for it.
   include(GzPkgConfig)
   gz_pkg_config_library_entry(GzOGRE2 OgreMain)
-else() #WIN32
+else() #PkgConfig_FOUND
 
   set(OGRE2_FOUND TRUE)
   set(OGRE_LIBRARIES "")


### PR DESCRIPTION
# 🎉 New feature

## Summary

On Windows  when pkg-config is available and Ogre-Next is available (for example on conda-forge), the code that currently is under `if(NOT WIN32)` works fine. To permit to use it without interfering with the case in which pkg-config is not installed, I change the `if(NOT WIN32)` to `if(PkgConfig_FOUND)`. 





## Test it

I tested that this works correctly with ogre-next installed by conda-forge, but I wonder if there is an easy way to ensure that this does not break the build of gz-rendering with ogre2/ogre-next installed by vcpkg (as done in CI jobs). 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
