### PR TITLE
Changelog.md: fix release number

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Gazebo CMake 3.x
 
-### Gazebo CMake 3.2.1 (2023-06-26)
+### Gazebo CMake 3.2.2 (2023-06-26)
 
 1. Fix incorrect if comparison in build_examples
     * [Pull request #356](https://github.com/gazebosim/gz-cmake/pull/356)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes release number in changelog, follow up to https://github.com/gazebosim/gz-cmake/pull/358/files#r1242612874

## Summary

minor typo

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
