### PR TITLE
GzConfigureProject: fix extras install

### DIFF
--- a/cmake/GzConfigureProject.cmake
+++ b/cmake/GzConfigureProject.cmake
@@ -162,7 +162,7 @@ macro(gz_configure_project)
     _gz_string_ends_with("${extra}" ".cmake.in" is_template)
     if(is_template)
       get_filename_component(extra_filename "${extra}" NAME)
-      # cut of .in extension
+      # cut off .in extension
       string(LENGTH "${extra_filename}" length)
       math(EXPR offset "${length} - 3")
       string(SUBSTRING "${extra_filename}" 0 ${offset} extra_filename)
@@ -180,7 +180,7 @@ macro(gz_configure_project)
     if(is_cmake)
       install(FILES
         ${extra}
-        DESTINATION lib/cmake/${PROJECT_NAME}/
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/
       )
       get_filename_component(extra_filename "${extra}" NAME)
       list(APPEND PACKAGE_CONFIG_EXTRA_FILES "${extra_filename}")


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/gazebosim/gz-transport/pull/398, noticed while testing https://github.com/gazebo-release/gz-msgs10-release/pull/3

## Summary

We have been fixing the debian metadata for gz-msgs10 in https://github.com/gazebo-release/gz-msgs10-release/pull/3, and I've built nightly debs from this branch successfully, but gz-transport fails to find the extra cmake files:

~~~
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs10-config.cmake:226 (include):
  include could not find requested file:

    /usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs-extras.cmake
Call Stack (most recent call first):
  /usr/share/cmake/gz-cmake3/cmake3/GzFindPackage.cmake:243 (find_package)
  CMakeLists.txt:87 (gz_find_package)
~~~

Looking at the location of installed cmake files in `libgz-msgs10-dev`:

~~~
/usr/lib/cmake/gz-msgs10/gz-msgs-extras.cmake
/usr/lib/cmake/gz-msgs10/gz_msgs_factory.cmake
/usr/lib/cmake/gz-msgs10/gz_msgs_generate.cmake
/usr/lib/cmake/gz-msgs10/gz_msgs_protoc.cmake
/usr/lib/cmake/gz-msgs10/gz_msgs_string_utils.cmake
/usr/lib/cmake/gz-msgs10/target_link_messages.cmake
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs10-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs10-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs10-targets-relwithdebinfo.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10/gz-msgs10-targets.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-all
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-all/gz-msgs10-all-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-all/gz-msgs10-all-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-all/gz-msgs10-all-targets.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-compiled
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-compiled/gz-msgs10-compiled-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-compiled/gz-msgs10-compiled-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-compiled/gz-msgs10-compiled-targets-relwithdebinfo.cmake
/usr/lib/x86_64-linux-gnu/cmake/gz-msgs10-compiled/gz-msgs10-compiled-targets.cmake
~~~

This changes the install location of the extra cmake files to use the `CMAKE_INSTALL_LIBDIR` variable, so that it matches the installation of the cmake config files.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
