### PR TITLE
Compute relative path for cmake extras

### DIFF
--- a/cmake/GzConfigureProject.cmake
+++ b/cmake/GzConfigureProject.cmake
@@ -153,6 +153,14 @@ macro(gz_configure_project)
     list(APPEND extras ${gz_configure_project_CONFIG_EXTRAS})
   endif()
 
+  #============================================================================
+  # Identify the operating system
+  gz_check_os()
+
+  #============================================================================
+  # Create package information
+  _gz_setup_packages()
+
   foreach(extra ${extras})
     _gz_assert_file_exists("${extra}"
       "gz_configure_project() called with extra file '${extra}' which does not exist")
@@ -189,14 +197,6 @@ macro(gz_configure_project)
         "does neither end with '.cmake' nor with '.cmake.in'.")
     endif()
   endforeach()
-
-  #============================================================================
-  # Identify the operating system
-  gz_check_os()
-
-  #============================================================================
-  # Create package information
-  _gz_setup_packages()
 
   #============================================================================
   # Initialize build errors/warnings

--- a/cmake/GzConfigureProject.cmake
+++ b/cmake/GzConfigureProject.cmake
@@ -161,6 +161,16 @@ macro(gz_configure_project)
   # Create package information
   _gz_setup_packages()
 
+  #============================================================================
+  # Configure and install cmake extras files
+  # Do this after _gz_setup_packages() to ensure GNUInstallDirs has been called
+  set(PROJECT_CMAKE_EXTRAS_INSTALL_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME})
+  file(RELATIVE_PATH
+    PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX
+    "${PROJECT_CMAKE_EXTRAS_INSTALL_DIR}"
+    "${CMAKE_INSTALL_PREFIX}"
+  )
+
   foreach(extra ${extras})
     _gz_assert_file_exists("${extra}"
       "gz_configure_project() called with extra file '${extra}' which does not exist")
@@ -188,7 +198,7 @@ macro(gz_configure_project)
     if(is_cmake)
       install(FILES
         ${extra}
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/
+        DESTINATION ${PROJECT_CMAKE_EXTRAS_INSTALL_DIR}
       )
       get_filename_component(extra_filename "${extra}" NAME)
       list(APPEND PACKAGE_CONFIG_EXTRA_FILES "${extra_filename}")


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/gazebosim/gz-transport/pull/398, follow-up to https://github.com/gazebosim/gz-cmake/pull/360 and https://github.com/gazebosim/gz-msgs/pull/339#discussion_r1247319505

## Summary

As noted in https://github.com/gazebosim/gz-msgs/pull/339#discussion_r1247319505, packages that install extra cmake files may need the relative path from the folder to which the extra cmake files are installed and the install prefix. In order to account for arch-specific lib folders (needed for debian installs to `/usr`, see [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html)), some code is rearranged so that the relative path is computed after the `_gz_setup_packages()` macro, since that is where `GNUInstallDirs` is included from, and before the extra cmake files are configured.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
