### PR TITLE
Prepare for 3.3.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.2.2)
+project(gz-cmake3 VERSION 3.3.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.3.0 (2023-08-10)
+
+1. GzConfigureProject: improve documentation
+    * [Pull request #364](https://github.com/gazebosim/gz-cmake/pull/364)
+
+1. Compute relative path for cmake extras
+    * [Pull request #362](https://github.com/gazebosim/gz-cmake/pull/362)
+
+1. GzConfigureProject: fix extras install
+    * [Pull request #360](https://github.com/gazebosim/gz-cmake/pull/360)
+
 ### Gazebo CMake 3.2.2 (2023-06-26)
 
 1. Fix incorrect if comparison in build_examples


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.3.0 release.

Comparison to 3.2.2: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.2.2...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
    - only changes to the changelog for 2.17.0 https://github.com/gazebosim/gz-cmake/pull/366
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [X] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.