### PR TITLE
Fix Github project automation for new project board

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request:
     types: [opened]
 name: Ticket opened
 jobs:
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add ticket to inbox
-        uses: technote-space/create-project-card-action@v1
+        uses: actions/add-to-project@v0.5.0
         with:
-          PROJECT: Core development
-          COLUMN: Inbox
-          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
-          CHECK_ORG_PROJECT: true
+          project-url: https://github.com/orgs/gazebosim/projects/7
+          github-token: ${{ secrets.TRIAGE_TOKEN }}
 


### PR DESCRIPTION
# Infrastructure

## Summary
This PR updates the action used for automatic project board assignment for issues/PRs now that we've migrated to the new Github Projects. The existing action seems to only work with Github Projects Classic. 

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.