### PR TITLE
Use `pull_request_target` for triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:


### PR DESCRIPTION
# Infrastructure

Follow up from #371.
Using the `pull_request_target` event allows this to work for PRs created from a fork. In `pull_request` event, the workflow doesn't have access to secrets, which is needed for the triage workflow. See https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git for the difference between `pull_request` and `pull_request_target` events.
