### PR TITLE
Fix pkg_config_entry when version number is not specified

### DIFF
--- a/cmake/GzPkgConfig.cmake
+++ b/cmake/GzPkgConfig.cmake
@@ -205,8 +205,11 @@ macro(ign_pkg_config_entry package string)
   gz_pkg_config_entry(${package} ${string})
 endmacro()
 macro(gz_pkg_config_entry package string)
-
-  set(${package}_PKGCONFIG_ENTRY "${string}")
+  # The input string may contain an operator without a version,
+  # e.g "protobuf >= ". But this is not valid pkg-config syntax. This regex
+  # search/replace will remove the operator if the version is empty.
+  string(REGEX REPLACE " *[<>=]+ *$" "" entry ${string})
+  set(${package}_PKGCONFIG_ENTRY "${entry}")
   set(${package}_PKGCONFIG_TYPE PKGCONFIG_REQUIRES)
 
 endmacro()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-transport/issues/412

## Summary
When `gz_find_package` is called without a VERSION argument, the `<package>_FIND_VERSION` variable is empty. But in most of our `Find*.cmake` modules, we add a pkg-config entry that assumes the version is there.

Example:
```
gz_pkg_config_entry(GzProtobuf "protobuf >= ${GzProtobuf_FIND_VERSION}")
```

The pkg-config entry will then be "protobuf >= ", which is invalid and causes the following entry to be treated as a version number.

The fix here removes the operator if the version is empty.

I believe this is why https://build.osrfoundation.org/job/gz-transport13-debbuilder/372/ is failing with 
```
Removing autopkgtest-satdep (0) ...
[33mautopkgtest [11:28:54]: test build: [-----------------------
[0mIn file included from /usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/transport13/gz/transport/Discovery.hh:71,
                 from /usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/transport13/gz/transport.hh:26,
                 from gztest.cc:1:
/usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/msgs10/gz/msgs/Utility.hh:24:10: fatal error: gz/math/AxisAlignedBox.hh: No such file or directory
   24 | #include <gz/math/AxisAlignedBox.hh>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[33mautopkgtest [11:28:54]: test build: -----------------------]
[0m[33mautopkgtest [11:28:54]: test build:  - - - - - - - - - - results - - - - - - - - - -
[0mbuild                FAIL non-zero exit status 1
[33mautopkgtest [11:28:54]: test build:  - - - - - - - - - - stderr - - - - - - - - - -
[0mIn file included from /usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/transport13/gz/transport/Discovery.hh:71,
                 from /usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/transport13/gz/transport.hh:26,
                 from gztest.cc:1:
/usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/gz/msgs10/gz/msgs/Utility.hh:24:10: fatal error: gz/math/AxisAlignedBox.hh: No such file or directory
   24 | #include <gz/math/AxisAlignedBox.hh>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The test uses pkg-config and checking the output of `pkg-config --libs gz-transport13` is 
```
-L/usr/lib/x86_64-linux-gnu/pkgconfig/../../..//lib/x86_64-linux-gnu -lgz-transport13 -lgz-utils2 -lgz-msgs10 -lprotobuf
```

**It doesn't include libgz-math7**. The contents of `/usr/lib/x86_64-linux-gnu/pkgconfig/gz-msgs10.pc` from `libgz-msgs10-dev` is:
```
prefix=${pcfiledir}/../../../
libdir=${prefix}/lib/x86_64-linux-gnu
includedir=${prefix}/include/gz/msgs10

Name: Gazebo msgs
Description: A set of msgs classes for robot applications
Version: 10.0.0
Requires: gz-cmake3 >= 1.1 protobuf >=  gz-math7
Requires.private: tinyxml2
Libs: -L${libdir} -lgz-msgs10 
Libs.private: 
CFlags: -I${includedir} 
```

We recently removed the required version of protobuf from gz-msgs (https://github.com/gazebosim/gz-msgs/pull/346) which explains why we haven't seen this failure in `gz-transport12-debbuilder` before.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
