### PR TITLE
Prepare for 3.3.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.3.0)
+project(gz-cmake3 VERSION 3.3.1)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,15 @@
 ## Gazebo CMake 3.x
 
-### Gazebo CMake 3.3.0 (2023-08-10)
+### Gazebo CMake 3.3.1 (2023-08-03)
+
+1. Fix pkg_config_entry when version number is not specified
+    * [Pull request #374](https://github.com/gazebosim/gz-cmake/pull/374)
+
+1. Infrastructure
+    * [Pull request #372](https://github.com/gazebosim/gz-cmake/pull/372)
+    * [Pull request #371](https://github.com/gazebosim/gz-cmake/pull/371)
+
+### Gazebo CMake 3.3.0 (2023-07-10)
 
 1. GzConfigureProject: improve documentation
     * [Pull request #364](https://github.com/gazebosim/gz-cmake/pull/364)


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.3.1 release.

Comparison to 3.3.0: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.3.0...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebo-release/gz-transport13-release/pull/3

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.