### PR TITLE
FindIgnOgre*: fix LIBRARY_DIRS and PLUGINDIR resolution when using pkgconfig

### DIFF
--- a/cmake/FindIgnOGRE.cmake
+++ b/cmake/FindIgnOGRE.cmake
@@ -99,15 +99,12 @@ if (NOT WIN32)
         set (OGRE_FOUND false)
       else ()
         # set library dirs if the value is empty
-        if (NOT ${OGRE_LIBRARY_DIRS} OR ${OGRE_LIBRARY_DIRS} STREQUAL "")
-          execute_process(COMMAND pkg-config --variable=libdir OGRE
-                          OUTPUT_VARIABLE _pkgconfig_invoke_result
-                          RESULT_VARIABLE _pkgconfig_failed)
-          if(_pkgconfig_failed)
+        if (NOT OGRE_LIBRARY_DIRS)
+          pkg_get_variable(OGRE_LIBRARY_DIRS OGRE libdir)
+          if(NOT OGRE_LIBRARY_DIRS)
             IGN_BUILD_WARNING ("Failed to find OGRE's library directory.  The build will succeed, but there will likely be run-time errors.")
           else()
-            # set ogre library dir and strip line break
-            set(OGRE_LIBRARY_DIRS ${_pkgconfig_invoke_result})
+            # strip line break
             string(REGEX REPLACE "\n$" "" OGRE_LIBRARY_DIRS "${OGRE_LIBRARY_DIRS}")
 
             string(FIND "${OGRE_LIBRARIES}" "${OGRE_LIBRARY_DIRS}" substr_found)
@@ -147,22 +144,18 @@ if (NOT WIN32)
       endif()
     endforeach()
 
-    execute_process(COMMAND pkg-config --variable=plugindir OGRE
-                    OUTPUT_VARIABLE _pkgconfig_invoke_result
-                    RESULT_VARIABLE _pkgconfig_failed)
-    if(_pkgconfig_failed)
+    pkg_get_variable(OGRE_PLUGINDIR OGRE plugindir)
+    if(NOT OGRE_PLUGINDIR)
       IGN_BUILD_WARNING ("Failed to find OGRE's plugin directory.  The build will succeed, but there will likely be run-time errors.")
     else()
-      # This variable will be substituted into cmake/setup.sh.in
-      set(OGRE_PLUGINDIR ${_pkgconfig_invoke_result})
+      # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems
+      # when we pass it to the compiler later.
+      string(REPLACE "\n" "" OGRE_PLUGINDIR ${OGRE_PLUGINDIR})
     endif()
 
     ign_pkg_config_library_entry(IgnOGRE OgreMain)
 
     set(OGRE_RESOURCE_PATH ${OGRE_PLUGINDIR})
-    # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems
-    # when we pass it to the compiler later.
-    string(REPLACE "\n" "" OGRE_RESOURCE_PATH ${OGRE_RESOURCE_PATH})
   endif()
 
   #reset pkg config path

--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -218,14 +218,13 @@ if (NOT WIN32)
     endif()
 
     # use pkg-config to find ogre plugin path
-    # do it here before resetting the pkg-config paths
-    execute_process(COMMAND pkg-config --variable=plugindir ${IGN_PKG_NAME}
-                    OUTPUT_VARIABLE _pkgconfig_invoke_result
-                    RESULT_VARIABLE _pkgconfig_failed)
-    if(_pkgconfig_failed)
+    # do it here before resetting the pkg-config paths  
+    pkg_get_variable(OGRE2_PLUGINDIR ${IGN_PKG_NAME} plugindir)
+
+    if(NOT OGRE2_PLUGINDIR)
       IGN_BUILD_WARNING ("Failed to find OGRE's plugin directory. The build will succeed, but there will likely be run-time errors.")
     else()
-      fix_pkgconfig_prefix_jammy_bug("${_pkgconfig_invoke_result}" OGRE2_PLUGINDIR)
+      fix_pkgconfig_prefix_jammy_bug("${OGRE2_PLUGINDIR}" OGRE2_PLUGINDIR)
     endif()
 
     # reset pkg config path


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes two problems:
1. When OGRE was found using `pkgconfig` the check if `LIBRARY_DIRS` is correctly set, still failed. This is corrected by simply using CMakes `if(<variable>)` syntax. This checks if the variable is defined and has a non-empty value.
2. When using `vcpkg` the `PKG_CONFIG_PATH` is not set and as a result `execute_process` calls to `pkg-config` wont find the by `vcpkg` installed dependencies. This is resolved by using `pkg_get_variable` instead.

## Checklist
- [X] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

