### PR TITLE
Only link against DL in the case that it is needed

### DIFF
--- a/cmake/GzRelocatableBinaries.cmake
+++ b/cmake/GzRelocatableBinaries.cmake
@@ -98,6 +98,7 @@ macro(gz_add_get_install_prefix_impl)
 
   # Write cpp for shared or module library type
   option(GZ_ENABLE_RELOCATABLE_INSTALL "If ON, enable the feature of providing a relocatable install prefix in shared library." OFF)
+
   if ((target_type STREQUAL "MODULE_LIBRARY" OR target_type STREQUAL "SHARED_LIBRARY") AND GZ_ENABLE_RELOCATABLE_INSTALL)
     # We can't query the LOCATION property of the target due to https://cmake.org/cmake/help/v3.25/policy/CMP0026.html
     # We can only access the directory of the library at generation time via $<TARGET_FILE_DIR:tgt>
@@ -208,7 +209,10 @@ endif()
   # Add cpp to library
   target_sources(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE ${gz_add_get_install_prefix_impl_GENERATED_CPP})
 
+# Only link DL in the case that it is needed.
+if ((target_type STREQUAL "MODULE_LIBRARY" OR target_type STREQUAL "SHARED_LIBRARY") AND GZ_ENABLE_RELOCATABLE_INSTALL)
   # Link DL_TARGET that provides dladdr
   target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE ${DL_TARGET})
+endif()
 
 endmacro()


### PR DESCRIPTION
https://github.com/gazebosim/gz-cmake/pull/334 added the ability to do binary relocatability.  

When enabled for shared libraries, it requires the additional dependence on `dl` for the `dladdr` symbol.  This was being unconditionally linked, even in the case that relocation was turned off.

This PR scopes the `dl` dependency to only when it is required.