### PR TITLE
Prepare for 3.4.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.3.1)
+project(gz-cmake3 VERSION 3.4.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.4.0 (2023-08-25)
+
+1. Only link against DL in the case that it is needed
+    * [Pull request #380](https://github.com/gazebosim/gz-cmake/pull/380)
+
+1. Disable building examples by default
+    * [Pull request #377](https://github.com/gazebosim/gz-cmake/pull/377)
+
+1. FindIgnOgre*: fix LIBRARY_DIRS and PLUGINDIR resolution when using pkgconfig
+    * [Pull request #376](https://github.com/gazebosim/gz-cmake/pull/376)
+
+1. Use CONFIG in gz_add_benchmark to avoid Windows collisions
+    * [Pull request #341](https://github.com/gazebosim/gz-cmake/pull/341)
+
 ### Gazebo CMake 3.3.1 (2023-08-03)
 
 1. Fix pkg_config_entry when version number is not specified

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 1. Only link against DL in the case that it is needed
     * [Pull request #380](https://github.com/gazebosim/gz-cmake/pull/380)
+    * [Pull request #382](https://github.com/gazebosim/gz-cmake/pull/382)
 
 1. Disable building examples by default
     * [Pull request #377](https://github.com/gazebosim/gz-cmake/pull/377)


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.4.0 release.

Comparison to 3.3.1: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.3.1...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-msgs/pull/368

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.