### PR TITLE
Use visibility hidden by default

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -9,8 +9,8 @@ release will remove the deprecated code.
 
 1. The minimum required cmake version is now 3.22.1.
 
-1. **Breaking**: C/C++ projects enable the visibility=hidden by default
-   gz-cmake4 changes the gz-cmake projects to use C/C++ visibility hidden
+1. **Breaking**: C/C++ projects enable the `visibility=hidden` compiler flag by default.
+   gz-cmake4 changes gz-cmake projects to use C/C++ visibility hidden
    by default. This is a potential breaking changed for projects using
    gz-cmake but the benefits in terms of creating portable code and
    time spend by the loader could be relevant.

--- a/Migration.md
+++ b/Migration.md
@@ -9,6 +9,17 @@ release will remove the deprecated code.
 
 1. The minimum required cmake version is now 3.22.1.
 
+1. **Breaking**: C/C++ projects enable the visibility=hidden by default
+   gz-cmake4 changes the gz-cmake projects to use C/C++ visibility hidden
+   by default. This is a potential breaking changed for projects using
+   gz-cmake but the benefits in terms of creating portable code and
+   time spend by the loader could be relevant.
+   To avoid this change, the EXPOSE_SYMBOLS_BY_DEFAULT flag can be used in
+   the gz_configure_project call.
+   The change deprecates the HIDDEN_SYMBOLS_BY_DEFAULT flag that can be
+   removed.
+
+
 ## Gazebo CMake 2.X to 3.X
 
 1. **Breaking**: Examples are now built using native cmake.

--- a/cmake/GzConfigureBuild.cmake
+++ b/cmake/GzConfigureBuild.cmake
@@ -24,15 +24,21 @@
 #################################################
 # Configure the build of the Gazebo project
 # Pass the argument HIDE_SYMBOLS_BY_DEFAULT to configure symbol visibility so
-# that symbols are hidden unless explicitly marked as visible.
+# that symbols are hidden unless explicitly marked as visible. (DEPRECATED)
+# Pass the argument EXPOSE_SYMBOLS_BY_DEFAULT to configure symbol visibility
+# so symbols are exposed unless explicitly marked as hidden.
 # Pass the argument QUIT_IF_BUILD_ERRORS to have this macro quit cmake when the
 # build_errors
 macro(gz_configure_build)
   # Parse the arguments that are passed in
-  set(options HIDE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
+  set(options HIDE_SYMBOLS_BY_DEFAULT EXPOSE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
   set(oneValueArgs)
   set(multiValueArgs COMPONENTS)
   cmake_parse_arguments(gz_configure_build "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(gz_configure_build_HIDE_SYMBOLS_BY_DEFAULT)
+    message(DEPRECATION "HIDE_SYMBOLS_BY_DEFAULT is now the default. You can safely remove the option.")
+  endif()
 
   #============================================================================
   # Examine the build type. If we do not recognize the type, we will generate

--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -123,12 +123,12 @@ endmacro()
 # Internal to gz-cmake.
 macro(_gz_setup_gcc_or_clang)
 
-  if(gz_configure_build_HIDE_SYMBOLS_BY_DEFAULT)
-    set(CMAKE_C_VISIBILITY_PRESET "hidden")
-    set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
-  else()
+  if(gz_configure_build_EXPOSE_SYMBOLS_BY_DEFAULT)
     set(CMAKE_C_VISIBILITY_PRESET "default")
     set(CMAKE_CXX_VISIBILITY_PRESET "default")
+  else()
+    set(CMAKE_C_VISIBILITY_PRESET "hidden")
+    set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
   endif()
 
 


### PR DESCRIPTION
# 🎉 New feature

Part of #166 

**Note:** all Ionic branches need to be checked and fixed before merging.

## Summary

The commit changes the gz-cmake projects to use C/C++ visibility hidden by default. This is a potential breaking changed for projects using  gz-cmake but the benefits in terms of creating portable code and time spend by the loader could be huge.
    
To avoid this change, the `EXPOSE_SYMBOLS_BY_DEFAULT` flag can be used in the gz_configure_project call.

The change deprecates the `HIDDEN_SYMBOLS_BY_DEFAULT` flag.

## Test it

Create an Ionic colcon workspace and build it with this branch.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.