### PR TITLE
Require cmake version 3.22.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,10 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo CMake 3.X to 4.X
+
+1. The minimum required cmake version is now 3.22.1.
+
 ## Gazebo CMake 2.X to 3.X
 
 1. **Breaking**: Examples are now built using native cmake.

--- a/MigrationFromClassic.md
+++ b/MigrationFromClassic.md
@@ -25,9 +25,9 @@ your project is migrated properly.
 ### Clear out your top-level `CMakeLists.txt` entirely
 That's right, just throw it all out.
 
-### Begin your top-level `CMakeLists.txt` with `cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)`
+### Begin your top-level `CMakeLists.txt` with `cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)`
 
-We're migrating to 3.10 because it provides many valuable features that we are
+We're migrating to 3.22 because it provides many valuable features that we are
 now taking advantage of.
 
 ### Then call `find_package(gz-cmake4 REQUIRED)`

--- a/cmake/gz-all-config.cmake.in
+++ b/cmake/gz-all-config.cmake.in
@@ -12,7 +12,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 if(@PKG_NAME@_ALL_CONFIG_INCLUDED)
   return()

--- a/cmake/gz-component-config.cmake.in
+++ b/cmake/gz-component-config.cmake.in
@@ -29,7 +29,7 @@
 # taking on these version settings, and then that stack will POP after the
 # find_package(~) has exited, so this will not affect the cmake policy settings
 # of a caller.
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 if(@component_pkg_name@_CONFIG_INCLUDED)
   return()

--- a/cmake/gz-config.cmake.in
+++ b/cmake/gz-config.cmake.in
@@ -30,7 +30,7 @@
 # taking on these version settings, and then that stack will POP after the
 # find_package(~) has exited, so this will not affect the cmake policy settings
 # of a caller.
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 if(NOT @PKG_NAME@_FIND_QUIETLY)
   message(STATUS "Looking for @PKG_NAME@ -- found version @PROJECT_VERSION_FULL@")

--- a/config/gz-cmake-config.cmake.in
+++ b/config/gz-cmake-config.cmake.in
@@ -13,7 +13,7 @@
 # taking on these version settings, and then that stack will POP after the
 # find_package(~) has exited, so this will not affect the cmake policy settings
 # of a caller.
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 if(@PKG_NAME@_CONFIG_INCLUDED)
   return()

--- a/examples/comp_deps/CMakeLists.txt
+++ b/examples/comp_deps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-component_deps VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project(

--- a/examples/core_child/CMakeLists.txt
+++ b/examples/core_child/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-core_child VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/core_child_private/CMakeLists.txt
+++ b/examples/core_child_private/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-core_child_private VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/core_nodep/CMakeLists.txt
+++ b/examples/core_nodep/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-core_no_deps VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project(

--- a/examples/core_nodep_static/CMakeLists.txt
+++ b/examples/core_nodep_static/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-core_no_deps_static VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project(

--- a/examples/core_static_child/CMakeLists.txt
+++ b/examples/core_static_child/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-core_static_child VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/find_ogre2/ogre-2.1/CMakeLists.txt
+++ b/examples/find_ogre2/ogre-2.1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-ogre-2.1 VERSION 0.1.0)
 
 find_package(gz-cmake4 REQUIRED)

--- a/examples/find_ogre2/ogre-2.2/CMakeLists.txt
+++ b/examples/find_ogre2/ogre-2.2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-ogre-2.2 VERSION 0.1.0)
 
 find_package(gz-cmake4 REQUIRED)

--- a/examples/find_ogre2/ogre-2.3/CMakeLists.txt
+++ b/examples/find_ogre2/ogre-2.3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-ogre-2.3 VERSION 0.1.0)
 
 find_package(gz-cmake4 REQUIRED)

--- a/examples/find_ogre2/ogre-2/CMakeLists.txt
+++ b/examples/find_ogre2/ogre-2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-ogre-2 VERSION 0.1.0)
 
 find_package(gz-cmake4 REQUIRED)

--- a/examples/find_ogre2/ogre/CMakeLists.txt
+++ b/examples/find_ogre2/ogre/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-ogre VERSION 0.1.0)
 
 find_package(gz-cmake4 REQUIRED)

--- a/examples/gz_conf/CMakeLists.txt
+++ b/examples/gz_conf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-minimal0 VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/no_gz_prefix/CMakeLists.txt
+++ b/examples/no_gz_prefix/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(no_gz_prefix VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project(

--- a/examples/prerelease/CMakeLists.txt
+++ b/examples/prerelease/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-minimal1 VERSION 1.0.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project(VERSION_SUFFIX pre1)

--- a/examples/sanitizers/CMakeLists.txt
+++ b/examples/sanitizers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-sanitizers VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/use_component_depsA/CMakeLists.txt
+++ b/examples/use_component_depsA/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-use_component_depsA VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/use_component_depsB/CMakeLists.txt
+++ b/examples/use_component_depsB/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-use_component_depsB VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/use_component_depsC/CMakeLists.txt
+++ b/examples/use_component_depsC/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-use_component_depsC VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 gz_configure_project()

--- a/examples/use_config_ifp/CMakeLists.txt
+++ b/examples/use_config_ifp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-find_config VERSION 0.1.0)
 find_package(gz-cmake4 REQUIRED)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/")


### PR DESCRIPTION
# 🎉 New feature

Part of #350.

## Summary

We already require 22.04 in Gazebo Garden, so we can require the version of cmake from that Ubuntu version ([which is 3.22.1](https://packages.ubuntu.com/jammy/cmake)) in our `main` branch, which will be used in Gazebo Ionic.

## Test it

Build on 22.04, macOS, or Windows with `-DBUILDSYSTEM_TESTING=ON`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
