### PR TITLE
Remove unix-specific fPIC flag

### DIFF
--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -77,18 +77,7 @@ endmacro()
 # Configure settings for Unix
 # Internal to gz-cmake.
 macro(_gz_setup_unix)
-
-  find_program(CMAKE_UNAME uname /bin /usr/bin /usr/local/bin )
-  if(CMAKE_UNAME)
-    exec_program(${CMAKE_UNAME} ARGS -m OUTPUT_VARIABLE CMAKE_SYSTEM_PROCESSOR)
-    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR} CACHE INTERNAL
-        "processor type (i386 and x86_64)")
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-      set(GZ_ADD_fPIC_TO_LIBRARIES true)
-      set(IGN_ADD_fPIC_TO_LIBRARIES ${GZ_ADD_fPIC_TO_LIBRARIES})  # TODO(CH3): Deprecated. Remove on tock.
-    endif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-  endif(CMAKE_UNAME)
-
+  # No custom setup for Unix systems
 endmacro()
 
 #################################################

--- a/cmake/GzUtils.cmake
+++ b/cmake/GzUtils.cmake
@@ -214,12 +214,6 @@ macro(_gz_add_library_or_component)
     add_library(${lib_name} ${sources})
   endif()
 
-  #------------------------------------
-  # Add fPIC if we are supposed to
-  if(GZ_ADD_fPIC_TO_LIBRARIES AND NOT _gz_add_library_INTERFACE)
-    target_compile_options(${lib_name} PRIVATE -fPIC)
-  endif()
-
   if(NOT _gz_add_library_INTERFACE)
 
     #------------------------------------


### PR DESCRIPTION
The `exec_program` call now raises a cmake warning in sufficiently new cmake versions, it was first triggered here: https://build.osrfoundation.org/job/gz_plugin-ci-pr_any-homebrew-amd64/4/cmake/

With the warning: `Policy CMP0153 is not set: The exec_program command should not be called.`

The policy is introduced in 3.28, which is probably why we are seeing it on homebrew first: https://cmake.org/cmake/help/latest/policy/CMP0153.html

---

Once I started looking at what was happening here, though, I think that we can remove the logic entirely.

Some things I noticed that I think are wrong:

* We are explicitly overriding `CMAKE_SYSTEM_PROCESSOR` with the contents of `uname`.  
  * In the default case `CMAKE_SYSTEM_PROCESSOR` should be set to `CMAKE_HOST_SYSTEM_PROCESSOR`  (See https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html) 
  * In the cross compilation case, the toolchain file sets `CMAKE_SYSTEM_PROCESSOR`
  * That means this is at best duplicate work, but is incorrectly overriding CMAKE_SYSTEM_PROCESSOR if someone is cross-compiling (I don't think we currently support this, but this would make it impossible).
* We are adding fPIC to libraries for x86_64 processors.
  * This should actually be controlled with https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html 
  * POSITION_INDEPENDENT_CODE is automatically added in the case of `MODULE` or `SHARED` library types, which would be the same as the logic here.
  * We are also excluding ARM/ARM64 in this logic, but I think it doesn't matter because CMake is already doing the right thing under the hood.

