### PR TITLE
Merge ign-cmake2 ➡️  gz-cmake3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-cmake[0-9]'
+      - 'gz-cmake[0-9]'
+      - 'main'
 
 jobs:
   focal-ci:
@@ -8,7 +14,7 @@ jobs:
     name: Ubuntu Focal CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@focal
@@ -19,7 +25,7 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/gazebosim/projects/7
           github-token: ${{ secrets.TRIAGE_TOKEN }}
-

--- a/Changelog.md
+++ b/Changelog.md
@@ -176,6 +176,11 @@
 
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.17.1 (2023-08-31)
+
+1. FindIgnOgre*: fix LIBRARY_DIRS and PLUGINDIR resolution when using pkgconfig
+    * [Pull request #376](https://github.com/gazebosim/gz-cmake/pull/376)
+
 ### Gazebo CMake 2.17.0 (2023-05-19)
 
 1. Use CONFIG in gz_add_benchmark to avoid Windows collisions


### PR DESCRIPTION
# ➡️  Forward port

Port `ign-cmake2 ` ➡️  `gz-cmake3`

Branch comparison: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3...ign-cmake2

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)