### PR TITLE
cppcheck uses c++17

### DIFF
--- a/cmake/GzCodeCheck.cmake
+++ b/cmake/GzCodeCheck.cmake
@@ -17,7 +17,7 @@ function(_gz_setup_target_for_codecheck)
   endif()
 
   # Base set of cppcheck option
-  set (CPPCHECK_BASE -q --inline-suppr -j 4 --language=c++ --std=c++14 --force)
+  set (CPPCHECK_BASE -q --inline-suppr -j 4 --language=c++ --std=c++17 --force)
   if (EXISTS "${PROJECT_BINARY_DIR}/cppcheck.suppress")
     set (CPPCHECK_BASE ${CPPCHECK_BASE} --suppressions-list=${PROJECT_BINARY_DIR}/cppcheck.suppress)
   endif()


### PR DESCRIPTION
Closes #378 


## Summary
Changed Line 20 of /cmake/GzCodeCheck.cmake to update a cppcheck parameter from c++14 to c++17

## Test it
I don't know exactly how to make tests for this, but I'm guessing you could:
Run  `cmake -DCMAKE_CXX_CPPCHECK:FILEPATH=cppcheck .` inside a package 
Or build and make workspaces and packages where Gazebo is used





