### PR TITLE
Use a relative symlink for Ign* cmake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ foreach(cmake_file ${tick_tocked_cmake_files})
         ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
   else()
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        ${CMAKE_INSTALL_PREFIX}\/${gz_modules_install_dir}\/${cmake_file} \
+        ${cmake_file} \
         ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
   endif()
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This unnecessarily absolute symlink inhibits relocation of the project after installation. The file being linked to is installed to the same directory, so a relative symlink is easy to produce.

This was flagged as a build warning during RPM packaging.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.