### PR TITLE
Preserve executable permissions when installing scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,17 +36,20 @@ add_subdirectory(doc)
 #--------------------------------------
 # Install the benchmark files
 install(DIRECTORY benchmark/
-        DESTINATION ${GZ_DATA_INSTALL_DIR}/benchmark)
+        DESTINATION ${GZ_DATA_INSTALL_DIR}/benchmark
+        USE_SOURCE_PERMISSIONS)
 
 #--------------------------------------
 # Install the codecheck files
 install(DIRECTORY codecheck/
-        DESTINATION ${GZ_DATA_INSTALL_DIR}/codecheck)
+        DESTINATION ${GZ_DATA_INSTALL_DIR}/codecheck
+        USE_SOURCE_PERMISSIONS)
 
 #--------------------------------------
 # Install the tools files
 install(DIRECTORY tools/
-        DESTINATION ${GZ_DATA_INSTALL_DIR}/tools)
+        DESTINATION ${GZ_DATA_INSTALL_DIR}/tools
+        USE_SOURCE_PERMISSIONS)
 
 #============================================================================
 # Configure the package to be installed


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
These scripts use a "shebang" to indicate what interpreter to use when directly invoking them from a shell, however when they are installed, the executable permissions are dropped meaning that they actually can't be invoked directly from a shell.

An alternative to this change might be to drop the "shebang" from the scripts if they are intended to be invoked explicitly using the desired interpreter, i.e. `sh tools/doc_check.sh`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.