### PR TITLE
Drop shebang from upload_doc.sh

### DIFF
--- a/cmake/upload_doc.sh.in
+++ b/cmake/upload_doc.sh.in
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 echo "Usage: sh upload_doc.sh [y/n]"
 echo "  Optional [y/n] argument indicates whether to upload the docs to S3 automatically."
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This file isn't directly executable in any of its forms:
* When checked into the repository, it is a template
* When installed by gz-cmake, it is still a template
* When expanded in downstream packages, it isn't explicitly given executable permission, requiring an explicit interpreter invocation

Additionally, the usage for this script instructs the user to explicitly provide the interpreter. To avoid misleading users and linters into believing that this file should be executed directly, drop the (currently unused) shebang.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.