### PR TITLE
Replace exec_program calls (not working out of the box in CMake 3.28)

### DIFF
--- a/cmake/GzCheckSSE.cmake
+++ b/cmake/GzCheckSSE.cmake
@@ -159,7 +159,7 @@ endif()
 
 IF (ARCH MATCHES "i386" OR ARCH MATCHES "x86_64")
   IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
-     EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
+     FILE(READ "/proc/cpuinfo" CPUINFO)
 
      STRING(REGEX REPLACE "^.*(sse2).*$" "\\1" SSE_THERE ${CPUINFO})
      STRING(COMPARE EQUAL "sse2" "${SSE_THERE}" SSE2_TRUE)
@@ -207,7 +207,7 @@ IF (ARCH MATCHES "i386" OR ARCH MATCHES "x86_64")
      ENDIF (SSE42_TRUE)
 
   ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-     EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE
+     EXECUTE_PROCESS(COMMAND "/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE
         CPUINFO)
 
      STRING(REGEX REPLACE "^.*[^S](SSE2).*$" "\\1" SSE_THERE ${CPUINFO})

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -7,10 +7,10 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling '$ENV{DESTDIR}${file}'")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing '$ENV{DESTDIR}${file}'")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
`exec_program` calls start to fail unless a given policy is set in CMake starting with Cmake 3.28 (the version in Noble). Replace the existing calls.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.