### PR TITLE
Prepare for 3.5.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.4.1)
+project(gz-cmake3 VERSION 3.5.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,40 @@
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.5.0 (2024-03-14)
+
+1. Remove @mxgrey as codeowner and assign maintainership to @scpeters
+    * [Pull request #414](https://github.com/gazebosim/gz-cmake/pull/414)
+
+1. Replace `exec_program` with `execute_process`
+    * [Pull request #402](https://github.com/gazebosim/gz-cmake/pull/402)
+
+1. cppcheck uses c++17
+    * [Pull request #404](https://github.com/gazebosim/gz-cmake/pull/404)
+
+1. Preserve executable permissions when installing scripts
+    * [Pull request #407](https://github.com/gazebosim/gz-cmake/pull/407)
+
+1. Use a consistent Python interpreter in all scripts
+    * [Pull request #406](https://github.com/gazebosim/gz-cmake/pull/406)
+
+1. Drop shebang from `upload_doc.sh`
+    * [Pull request #408](https://github.com/gazebosim/gz-cmake/pull/408)
+
+1. Use a relative symlink for `Ign*` cmake modules
+    * [Pull request #405](https://github.com/gazebosim/gz-cmake/pull/405)
+
+1. Remove exec_program call
+    * [Pull request #399](https://github.com/gazebosim/gz-cmake/pull/399)
+
+1. Update CI badges in README
+    * [Pull request #398](https://github.com/gazebosim/gz-cmake/pull/398)
+
+1. Infrastructure
+    * [Pull request #395](https://github.com/gazebosim/gz-cmake/pull/395)
+
+1. Change `EXTRA_ARGS` to be a `multiValueArgs` in `GzFindPackage`
+    * [Pull request #393](https://github.com/gazebosim/gz-cmake/pull/393)
+
 ### Gazebo CMake 3.4.1 (2023-09-26)
 
 1. Fixed finding Ogre2 on Windows+Conda


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.5.0 release.

Comparison to 3.4.1: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.4.1...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-plugin/pull/138 (to fix cmake warning)

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.