### PR TITLE
Fix how `ign` compatibility files are copied in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ foreach(cmake_file ${tick_tocked_cmake_files})
 
   if (WIN32)  # Windows requires copy instead of symlink
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E copy \
-        ${CMAKE_INSTALL_PREFIX}\/${gz_modules_install_dir}\/${cmake_file} \
+        ${PROJECT_SOURCE_DIR}\/cmake/${cmake_file} \
         ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
   else()
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Instead of relying on the installed `gz` cmake file, we copy the one from the source directory. This avoids relying on an absolute path formed using `CMAKE_INSTALL_PREFIX`, which doesn't work well when using `CMAKE_STAGING_PREFIX`.

This is needed to fix windows build failure of `gz_cmake_vendor`. https://ci.ros2.org/job/ci_windows/21361/console#console-section-25

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
