### PR TITLE
Prepare for 3.5.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.5.0)
+project(gz-cmake3 VERSION 3.5.1)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo CMake 3.x
 
+### Gazebo Cmake 3.5.1 (2024-03-29)
+
+1. Fix how `ign` compatibility files are copied in windows
+    * [Pull request #419](https://github.com/gazebosim/gz-cmake/pull/419)
+
 ### Gazebo CMake 3.5.0 (2024-03-14)
 
 1. Remove @mxgrey as codeowner and assign maintainership to @scpeters


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.5.1 release.

Comparison to 3.5.0: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.5.0...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.