### PR TITLE
Remove example_INSTALL_DIR from PREFIX_PATH on examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -88,7 +88,7 @@ foreach(example ${example_directories})
       # See alternate approach in a2113e0997c9 if this becomes too slow
       BUILD_ALWAYS 1
       CMAKE_ARGS
-        "-DCMAKE_PREFIX_PATH=${FAKE_INSTALL_PREFIX};${example_INSTALL_DIR}"
+        "-DCMAKE_PREFIX_PATH=${FAKE_INSTALL_PREFIX}"
         "-DCMAKE_BUILD_TYPE=${build_type}"
         "-DCMAKE_INSTALL_PREFIX=${example_INSTALL_DIR}"
       TEST_COMMAND


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Remove the `example_INSTALL_DIR` to be passed to `CMAKE_PREFIX_PATH` since it is probably unused since the separator is wrong (semicolon instead of a colon). This triggered my attention since Noble has a warning with 3.28 CMake version.

```
CMake Warning:
  Ignoring extra path from command line:

   "/home/jenkins/workspace/gz_cmake-ci-gz-cmake3-noble-amd64/build/install/RelWithDebInfo"


CMake Warning:
  Ignoring extra path from command line:

   "/home/jenkins/workspace/gz_cmake-ci-gz-cmake3-noble-amd64/build/install/RelWithDebInfo"


CMake Warning:
  Ignoring extra path from command line:

   "/home/jenkins/workspace/gz_cmake-ci-gz-cmake3-noble-amd64/build/install/Release"


CMake Warning:
  Ignoring extra path from command line:

   "/home/jenkins/workspace/gz_cmake-ci-gz-cmake3-noble-amd64/build/install/Release"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.