### PR TITLE
Use relative install paths for extra cmake files

### DIFF
--- a/cmake/GzConfigureProject.cmake
+++ b/cmake/GzConfigureProject.cmake
@@ -30,6 +30,7 @@
 #   GZ_DESIGNATION_LOWER
 #   GZ_DESIGNATION_UPPER
 #   PKG_NAME
+#   PROJECT_CMAKE_EXTRAS_RELATIVE_INSTALL_DIR
 #   PROJECT_CMAKE_EXTRAS_INSTALL_DIR
 #   PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX
 #   PROJECT_INCLUDE_DIR
@@ -194,6 +195,7 @@ macro(gz_configure_project)
   #============================================================================
   # Configure and install cmake extras files
   # Do this after _gz_setup_packages() to ensure GNUInstallDirs has been called
+  set(PROJECT_CMAKE_EXTRAS_RELATIVE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   set(PROJECT_CMAKE_EXTRAS_INSTALL_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME})
   file(RELATIVE_PATH
     PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX
@@ -228,7 +230,7 @@ macro(gz_configure_project)
     if(is_cmake)
       install(FILES
         ${extra}
-        DESTINATION ${PROJECT_CMAKE_EXTRAS_INSTALL_DIR}
+        DESTINATION ${PROJECT_CMAKE_EXTRAS_RELATIVE_INSTALL_DIR}
       )
       get_filename_component(extra_filename "${extra}" NAME)
       list(APPEND PACKAGE_CONFIG_EXTRA_FILES "${extra_filename}")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes an error when building https://github.com/gazebo-release/gz_msgs_vendor/ in the ROS buildfarm.

Similar to https://github.com/gazebosim/gz-tools/pull/137

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
