### PR TITLE
Fix installation of `Ign*.cmake` modules on newer versions of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,19 +182,23 @@ set(tick_tocked_cmake_files
 foreach(cmake_file ${tick_tocked_cmake_files})
   string(REGEX REPLACE "^Gz" "Ign" ign_cmake_file ${cmake_file})
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cmake")
+  set(ign_cmake_file_path "${PROJECT_BINARY_DIR}/cmake/${ign_cmake_file}")
 
   if (WIN32)  # Windows requires copy instead of symlink
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E copy \
-        ${PROJECT_SOURCE_DIR}\/cmake/${cmake_file} \
-        ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
+    add_custom_command(OUTPUT ${ign_cmake_file_path}
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${PROJECT_SOURCE_DIR}/cmake/${cmake_file}  ${ign_cmake_file_path}
+    )
   else()
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        ${cmake_file} \
-        ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
+    add_custom_command(OUTPUT ${ign_cmake_file_path}
+      COMMAND ${CMAKE_COMMAND} -E create_symlink
+      ${cmake_file}  ${ign_cmake_file_path}
+    )
   endif()
 
+  add_custom_target(target_${ign_cmake_file} ALL DEPENDS ${ign_cmake_file_path})
   install(
-    FILES ${PROJECT_BINARY_DIR}/cmake/${ign_cmake_file}
+    FILES ${ign_cmake_file_path}
     DESTINATION ${gz_modules_install_dir}
     COMPONENT modules)
 endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Previously, we expected `install(CODE ...)`,  to run before `install(FILES ...)` since that is the order they appear in the CMakeLists.txt file. `install(CODE ...)` was responsible for creating a copy or symlink of `Gz*.cmake` files to `Ign*.cmake` 
 and putting them in a temporary location.   `install(FILES ...)` would then copy those files to the final install destination. However, it appears that on CMake 3.29.2 (tested on windows), we can no longer rely on the order they appear in the code. From my local testing, `install(CODE ...)` ran after `install(FILES ...)`.

This PR uses `add_custom_command` to generate the `Ign*.cmake` files which avoids any reliance on the order of the `install` calls.

This was caught during the ROS 2 tutorial party (see https://github.com/osrf/ros2_test_cases/issues/1526)

cc @clalancette 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
