### PR TITLE
Prepare for release 2.17.2 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.17.1)
+project(ignition-cmake2 VERSION 2.17.2)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Gazebo CMake 2.17.2 (2024-05-07)
 
 1. Backport #402: Replace `exec_program` with `execute_process`
-    * [Pull request #402: Replace `exec_program` with `execute_process` (#427](https://github.com/gazebosim/gz-cmake/pull/402: Replace `exec_program` with `execute_process` (#427)
+    * [Pull request #402](https://github.com/gazebosim/gz-cmake/pull/402)
 
 1. Remove @mxgrey as codeowner and assign maintainership to @scpeters
     * [Pull request #414](https://github.com/gazebosim/gz-cmake/pull/414)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Gazebo CMake 2.x
 
-### Gazebo CMake 2.17.2 (2024-04-07)
+### Gazebo CMake 2.17.2 (2024-05-07)
 
 1. Backport #402: Replace `exec_program` with `execute_process`
     * [Pull request #402: Replace `exec_program` with `execute_process` (#427](https://github.com/gazebosim/gz-cmake/pull/402: Replace `exec_program` with `execute_process` (#427)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.17.2 (2024-04-07)
+
+1. Backport #402: Replace `exec_program` with `execute_process`
+    * [Pull request #402: Replace `exec_program` with `execute_process` (#427](https://github.com/gazebosim/gz-cmake/pull/402: Replace `exec_program` with `execute_process` (#427)
+
+1. Remove @mxgrey as codeowner and assign maintainership to @scpeters
+    * [Pull request #414](https://github.com/gazebosim/gz-cmake/pull/414)
+
+1. Update github action workflows
+    * [Pull request #395](https://github.com/gazebosim/gz-cmake/pull/395)
+
 ### Gazebo CMake 2.17.1 (2023-08-31)
 
 1. FindIgnOgre*: fix LIBRARY_DIRS and PLUGINDIR resolution when using pkgconfig


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.17.2 release.

[Comparison to <x.y.z>: https://github.com/gazebosim/<REPO>/compare/<LATEST_TAG_BRANCH>...<RELEASE_BRANCH>](https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.17.1...ign-cmake2)

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.