### PR TITLE
Deprecate GzPython.cmake

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -19,6 +19,9 @@ release will remove the deprecated code.
    The change deprecates the HIDDEN_SYMBOLS_BY_DEFAULT flag that can be
    removed.
 
+1. **Deprecated**: `GzPython.cmake`
+    **Replacement**: Use `find_package(Python3)` to find Python3 and the
+              `Python3_EXECUTABLE` variable instead of `PYTHON_EXECUTABLE`.
 
 ## Gazebo CMake 2.X to 3.X
 

--- a/cmake/GzBuildTests.cmake
+++ b/cmake/GzBuildTests.cmake
@@ -107,7 +107,9 @@ macro(gz_build_tests)
 
     # Find the Python interpreter for running the
     # check_test_ran.py script
-    include(GzPython)
+    if(NOT Python3_Interpreter_FOUND)
+      find_package(Python3 COMPONENTS Interpreter)
+    endif()
 
     # Build all the tests
     foreach(target_name ${test_list})

--- a/cmake/GzCodeCheck.cmake
+++ b/cmake/GzCodeCheck.cmake
@@ -1,7 +1,9 @@
 # Setup the codecheck target, which will run cppcheck and cppplint.
 # This function is private to gz-cmake.
 function(_gz_setup_target_for_codecheck)
-  include(GzPython)
+  if(NOT Python3_Interpreter_FOUND)
+    find_package(Python3 COMPONENTS Interpreter)
+  endif()
 
   find_program(CPPCHECK_PATH cppcheck)
   find_program(FIND_PATH find)

--- a/cmake/GzPython.cmake
+++ b/cmake/GzPython.cmake
@@ -12,31 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
-  set(GZ_PYTHON_VERSION "" CACHE STRING
-    "Specify specific Python3 version to use ('major.minor' or 'versionMin...[<]versionMax')")
+message(WARNING "GzPython is deprecated, use find_package(Python3) instead.")
 
-  find_package(Python3 ${GZ_PYTHON_VERSION} QUIET)
-elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
-  # no support for finding specific versions
-  find_package(Python3 QUIET)
-else()
-  # TODO: remove this block as soon as the CMake version can safely be bumped to => 3.12
-  set(GZ_PYTHON_VERSION "" CACHE STRING
-    "Specify specific Python version to use ('major.minor' or 'major')")
+set(GZ_PYTHON_VERSION "" CACHE STRING
+  "Specify specific Python3 version to use ('major.minor' or 'versionMin...[<]versionMax')")
 
-  # if not specified otherwise use Python 3
-  if(NOT GZ_PYTHON_VERSION)
-    set(GZ_PYTHON_VERSION "3")
-  endif()
-
-  find_package(PythonInterp ${GZ_PYTHON_VERSION} QUIET)
-
-  if(PYTHONINTERP_FOUND)
-    set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
-    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-  endif()
-endif()
+find_package(Python3 ${GZ_PYTHON_VERSION} QUIET)
 
 # Tick-tock PYTHON_EXECUTABLE until Python3_EXECUTABLE is released
 # TODO(jrivero) gz-cmake4: start the deprecation cycle of PYTHON_EXECUTABLE


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/issues/350

## Summary

Using `GzPython.cmake` to find python is not ideal since it's best to find python once with the components that you need. Now that `find_package(Python3)` works well, it's best to just use that.

All Gazebo packages in Ionic have stopped using `GzPython`, so this should be safe to merge.

* https://github.com/gazebosim/gz-math/pull/588
* https://github.com/gazebosim/gz-physics/pull/625
* https://github.com/gazebosim/gz-rendering/pull/990)

## Test it

Compile Gazebo Ionic from source against this branch and ensure there are no cmake warnings from using GzPython and that python bindings are properly built for each package.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

