### PR TITLE
Fix link for Sanitizer Builds tutorial

### DIFF
--- a/tutorials/gz_cmake_sanitizers.md
+++ b/tutorials/gz_cmake_sanitizers.md
@@ -1,4 +1,4 @@
-# Sanitizer Builds
+\page sanitizersbuilds Sanitizer Builds
 
 ## Original source and Copyright
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The [link](https://gazebosim.org/api/cmake/3/tutorials.html) is currently broken: 
![image](https://github.com/gazebosim/gz-cmake/assets/206116/752bf0b9-f410-4424-abd4-c2dd68c580df)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
