### PR TITLE
Revert "Fix lcov on Ubuntu Noble (#436)"

### DIFF
--- a/cmake/GzCodeCoverage.cmake
+++ b/cmake/GzCodeCoverage.cmake
@@ -141,13 +141,11 @@ FUNCTION(gz_setup_target_for_coverage)
     # Capturing lcov counters and generating report
     COMMAND ${LCOV_PATH} ${_branch_flags} -q --no-checksum
       --directory ${PROJECT_BINARY_DIR} --capture
-      --rc geninfo_unexecuted_blocks=1
-      --ignore-errors mismatch,mismatch
       --output-file ${_outputname}.info 2>/dev/null
     # Remove negative counts
     COMMAND sed -i '/,-/d' ${_outputname}.info
     COMMAND ${LCOV_PATH} ${_branch_flags} -q
-      --remove ${_outputname}.info --ignore-errors unused,unused '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' '*.pb.*' '*/build/*' '*/install/*' ${IGNORE_LIST} --output-file ${_outputname}.info.cleaned
+      --remove ${_outputname}.info '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' '*.pb.*' '*/build/*' '*/install/*' ${IGNORE_LIST} --output-file ${_outputname}.info.cleaned
     COMMAND ${GENHTML_PATH} ${_branch_flags} -q --prefix ${PROJECT_SOURCE_DIR}
     --legend -o ${_outputname} ${_outputname}.info.cleaned
     COMMAND ${LCOV_PATH} --summary ${_outputname}.info.cleaned 2>&1 | grep "lines" | cut -d ' ' -f 4 | cut -d '%' -f 1 > ${_outputname}/lines.txt


### PR DESCRIPTION
# 🦟 Bug fix

This reverts commit 930e17fa831daefff6f8905bc864e63fd028a20a (from #436) since it breaks GitHub workflows using Jammy for code coverage (there are still many Ionic packages using Jammy for codecov).

## Summary

Revert to unbreak workflows until we can fix things better (see https://github.com/gazebosim/gz-utils/pull/133 for an example failure).

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
