### PR TITLE
Use relative paths for pkg-config install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ set(gz_version_output "${PROJECT_NAME_LOWER}-config-version.cmake")
 set(gz_config_install_dir "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME_LOWER}")
 set(gz_pkgconfig_input "${CMAKE_CURRENT_SOURCE_DIR}/config/gz-cmake.pc.in")
 set(gz_pkgconfig_output "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
-set(gz_pkgconfig_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+set(gz_pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+set(gz_pkgconfig_abs_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
 set(gz_utilities_target ${PROJECT_EXPORT_NAME}-utilities)
 set(gz_utilities_import_target_name ${PROJECT_EXPORT_NAME}::${gz_utilities_target})
 set(gz_utilities_target_output_filename "${gz_utilities_target}-targets.cmake")
@@ -96,7 +97,7 @@ install(
 # Configure and install the pkgconfig file (needed for utilities headers)
 file(RELATIVE_PATH
   GZ_PC_CONFIG_RELATIVE_PATH_TO_PREFIX
-  "${gz_pkgconfig_install_dir}"
+  "${gz_pkgconfig_abs_install_dir}"
   "${CMAKE_INSTALL_PREFIX}"
 )
 

--- a/cmake/GzPackaging.cmake
+++ b/cmake/GzPackaging.cmake
@@ -199,10 +199,11 @@ function(_gz_create_pkgconfig)
   endif()
 
   set(pkgconfig_output "${CMAKE_BINARY_DIR}/cmake/pkgconfig/${target_name}.pc")
-  set(pkgconfig_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+  set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  set(pkgconfig_abs_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
   file(RELATIVE_PATH
     PC_CONFIG_RELATIVE_PATH_TO_PREFIX
-    "${pkgconfig_install_dir}"
+    "${pkgconfig_abs_install_dir}"
     "${CMAKE_INSTALL_PREFIX}"
   )
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This makes it so that all of our libraries use relative install paths and work well in build systems that don't set `CMAKE_INSTALL_PREFIX`.

`gz_cmake_vendor` is [patched](https://github.com/gazebo-release/gz_cmake_vendor/blob/rolling/patches/0001-fix-pkg-config-dir.patch) with this so it can build on the ROS buildfarm (see https://github.com/gazebo-release/gz_cmake_vendor/pull/4).

With this patch, running `cmake  -DCMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION=ON -P cmake_install.cmake` from the `build` directory of any of our libraries will succeed showing that no absolute install destination is used.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.