### PR TITLE
Merge gz-cmake3 ➡️  gz-cmake4

### DIFF
--- a/tutorials/gz_cmake_sanitizers.md
+++ b/tutorials/gz_cmake_sanitizers.md
@@ -1,4 +1,4 @@
-# Sanitizer Builds
+\page sanitizersbuilds Sanitizer Builds
 
 ## Original source and Copyright
 


### PR DESCRIPTION
# ➡️  Forward port
 
  Port `gz-cmake3 ` ➡️  `gz-cmake4`

  Branch comparison: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4...gz-cmake3

This fixes the broken link in gz-cmake4 [tutorial](https://gazebosim.org/api/cmake/4/tutorials.html)
![image](https://github.com/user-attachments/assets/93f8335c-1f12-4713-bd16-1b256eda1c00)



  **Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)