### PR TITLE
Specify required components in pkg-config

### DIFF
--- a/cmake/gz-config.cmake.in
+++ b/cmake/gz-config.cmake.in
@@ -148,9 +148,8 @@ endif()
 set(@LEGACY_PROJECT_PREFIX@_LIBRARIES ${@PKG_NAME@_LIBRARIES})
 set(@LEGACY_PROJECT_PREFIX@_INCLUDE_DIRS ${@PKG_NAME@_INCLUDE_DIRS})
 
-# This macro is used by gz-cmake to automatically configure the pkgconfig
-# files for Gazebo projects.
-gz_pkg_config_entry(@PKG_NAME@ "@PKG_NAME@")
+# required pkg-config components
+set(@PKG_NAME@_required_components)
 
 # Find each of the components requested by find_package(~)
 foreach(component ${@PKG_NAME@_FIND_COMPONENTS})
@@ -166,6 +165,8 @@ foreach(component ${@PKG_NAME@_FIND_COMPONENTS})
     # find_dependency(~)
     find_dependency(@PKG_NAME@-${component} @PROJECT_VERSION_FULL_NO_SUFFIX@ EXACT)
 
+    set(@PKG_NAME@_required_components "${@PKG_NAME@_required_components} @PKG_NAME@-${component}")
+
   else()
 
     # If this is an optional component, use find_package(~) instead of
@@ -176,6 +177,11 @@ foreach(component ${@PKG_NAME@_FIND_COMPONENTS})
   endif()
 
 endforeach()
+
+# This macro is used by gz-cmake to automatically configure the pkgconfig
+# files for Gazebo projects.
+gz_pkg_config_entry(@PKG_NAME@ "@PKG_NAME@ ${@PKG_NAME@_required_components}")
+unset(@PKG_NAME@_required_components)
 
 # Specify the doxygen tag file
 set(@PROJECT_NAME_NO_VERSION_UPPER@_DOXYGEN_TAGFILE "${PACKAGE_PREFIX_DIR}/@GZ_DATA_INSTALL_DIR@/@PROJECT_NAME_LOWER@.tag.xml")


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-cmake/issues/450.

## Summary

When a `gz-*` package is found with `find_package`, its cmake config file encodes the list of required dependencies in its pkg-config file. If the package is found with required components, those components should be encoded in the pkg-config file as well. This uses the existing for loop over components in the `gz-config.cmake.in` file and stores the names of required components, then appends them to the string passed to `gz_pkg_config_entry`.

I spent some time trying to add a test for this in branch `scpeters/test_component_export` ( https://github.com/gazebosim/gz-cmake/compare/gz-cmake4...scpeters/test_component_export ) but have not yet been successful. I've tested this fix manually and think it works.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
