### PR TITLE
Prepare for 4.1.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake4 VERSION 4.0.0)
+project(gz-cmake4 VERSION 4.1.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 ### Gazebo CMake 4.1.0 (2024-11-01)
 
-1. Update lib into  triage.yml
+1. Update add-to-project version in triage.yml
     * [Pull request #448](https://github.com/gazebosim/gz-cmake/pull/448)
+    * [Pull request #459](https://github.com/gazebosim/gz-cmake/pull/459)
 
 1. Helper to get version number from package.xml
     * [Pull request #456](https://github.com/gazebosim/gz-cmake/pull/456)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo CMake 4.x
 
+### Gazebo CMake 4.1.0 (2024-11-01)
+
+1. Update lib into  triage.yml
+    * [Pull request #448](https://github.com/gazebosim/gz-cmake/pull/448)
+
+1. Helper to get version number from package.xml
+    * [Pull request #456](https://github.com/gazebosim/gz-cmake/pull/456)
+
 ### Gazebo CMake 4.0.0 (2024-09-25)
 
 1. Miscellaneous documentation fixes

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-cmake4</name>
-  <version>4.0.0</version>
+  <version>4.1.0</version>
   <description>Gazebo CMake : CMake Modules for Gazebo Projects</description>
 
   <maintainer email="scpeters@openrobotics.org">Steve Peters</maintainer>


### PR DESCRIPTION
# 🎈 Release

Preparation for 4.1.0 release.

Comparison to 4.0.0: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4_4.0.0...gz-cmake4

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-math/pull/639

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.