### PR TITLE
Ensure that find_package(TinyXML2) defines tinyxml2::tinyxml2 even on case insensitive filesystems

### DIFF
--- a/cmake/FindTINYXML2.cmake
+++ b/cmake/FindTINYXML2.cmake
@@ -63,3 +63,14 @@ if(NOT TINYXML2_FOUND)
     REQUIRED_VARS TINYXML2_FOUND)
 
 endif()
+
+# On case-insensitive filesystem, it is possible that FindTINYXML2.cmake is used if the caller
+# invoked find_package(TinyXML2), that is the signature used by tinyxml2_vendor, see
+# https://github.com/ros2/tinyxml2_vendor/blob/0.10.0/cmake/Modules/FindTinyXML2.cmake
+# If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME)
+# we also define a tinyxml2::tinyxml2 target for tinyxml2_vendor compatibility
+if(TARGET TINYXML2::TINYXML2 AND CMAKE_FIND_PACKAGE_NAME STREQUAL "TinyXML2" AND NOT TARGET tinyxml2::tinyxml2)
+  add_library(tinyxml2::tinyxml2 INTERFACE IMPORTED)
+  set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_LINK_LIBRARIES TINYXML2::TINYXML2)
+endif()
+


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

On case-insensitive filesystem, it is possible that FindTinyXML2.cmake is used if the caller invoked find_package(TINYXML2), that is the signature used by tinyxml2_vendor, see https://github.com/ros2/tinyxml2_vendor/blob/b66cece6ed99ba3c3b2b64bc56c0f717dd33243b/cmake/Modules/FindTinyXML2.cmake .

If that is the case (and we detect it by checking the value of CMAKE_FIND_PACKAGE_NAME) we also define a tinyxml2::tinyxml2 target for tinyxml2_vendor compatibility.

This is a sister PR of https://github.com/ros2/tinyxml2_vendor/pull/22 .

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

