### PR TITLE
Normalize header install path

### DIFF
--- a/cmake/GzInstallAllHeaders.cmake
+++ b/cmake/GzInstallAllHeaders.cmake
@@ -157,8 +157,9 @@ function(gz_install_all_headers)
 
     set(component_name ${gz_install_all_headers_COMPONENT})
 
-    # Define the install directory for the component "meta" header
-    set(meta_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}/${component_name})
+    # Define the install directory for the "config" header
+    # The "meta" header will be installed one folder above this
+    set(config_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
 
     # Define the input/output of the configuration for the component "meta" header
     set(meta_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
@@ -166,8 +167,9 @@ function(gz_install_all_headers)
 
   else()
 
-    # Define the install directory for the core "meta" header
-    set(meta_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
+    # Define the install directory for the "config" header
+    # The core "meta" header will be installed one folder above this
+    set(config_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
 
     # Define the input/output of the configuration for the core "meta" header
     set(meta_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
@@ -175,13 +177,16 @@ function(gz_install_all_headers)
 
   endif()
 
+  # Generate the install directory for the "meta" header one folder above the "config" header
+  cmake_path(SET meta_header_install_dir NORMALIZE ${config_header_install_dir}/..)
+
   # Generate the "meta" header that includes all of the headers
   configure_file(${meta_header_in} ${meta_header_out})
 
   # Install the "meta" header
   install(
     FILES ${meta_header_out}
-    DESTINATION ${meta_header_install_dir}/..
+    DESTINATION ${meta_header_install_dir}
     COMPONENT headers)
 
   # Define the input/output of the configuration for the "config" header
@@ -207,7 +212,7 @@ function(gz_install_all_headers)
     # Install the "config" header
     install(
       FILES ${config_header_out}
-      DESTINATION ${meta_header_install_dir}
+      DESTINATION ${config_header_install_dir}
       COMPONENT headers)
 
   endif()

--- a/cmake/GzInstallAllHeaders.cmake
+++ b/cmake/GzInstallAllHeaders.cmake
@@ -159,7 +159,7 @@ function(gz_install_all_headers)
 
     # Define the install directory for the "config" header
     # The "meta" header will be installed one folder above this
-    set(config_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
+    set(config_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}/${component_name})
 
     # Define the input/output of the configuration for the component "meta" header
     set(meta_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)

--- a/cmake/GzInstallAllHeaders.cmake
+++ b/cmake/GzInstallAllHeaders.cmake
@@ -157,30 +157,30 @@ function(gz_install_all_headers)
 
     set(component_name ${gz_install_all_headers_COMPONENT})
 
-    # Define the install directory for the component meta header
+    # Define the install directory for the component "meta" header
     set(meta_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}/${component_name})
 
-    # Define the input/output of the configuration for the component "master" header
-    set(master_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
-    set(master_header_out ${CMAKE_CURRENT_BINARY_DIR}/${component_name}.hh)
+    # Define the input/output of the configuration for the component "meta" header
+    set(meta_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
+    set(meta_header_out ${CMAKE_CURRENT_BINARY_DIR}/${component_name}.hh)
 
   else()
 
-    # Define the install directory for the core master meta header
+    # Define the install directory for the core "meta" header
     set(meta_header_install_dir ${GZ_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
 
-    # Define the input/output of the configuration for the core "master" header
-    set(master_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
-    set(master_header_out ${CMAKE_CURRENT_BINARY_DIR}/../${GZ_DESIGNATION}.hh)
+    # Define the input/output of the configuration for the core "meta" header
+    set(meta_header_in ${GZ_CMAKE_DIR}/gz_auto_headers.hh.in)
+    set(meta_header_out ${CMAKE_CURRENT_BINARY_DIR}/../${GZ_DESIGNATION}.hh)
 
   endif()
 
-  # Generate the "master" header that includes all of the headers
-  configure_file(${master_header_in} ${master_header_out})
+  # Generate the "meta" header that includes all of the headers
+  configure_file(${meta_header_in} ${meta_header_out})
 
-  # Install the "master" header
+  # Install the "meta" header
   install(
-    FILES ${master_header_out}
+    FILES ${meta_header_out}
     DESTINATION ${meta_header_install_dir}/..
     COMPONENT headers)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #461

## Summary

The "meta" header file that contains includes of all other core / component header files is installed to a relative path, one folder above the other include files. This was causing a cmake warning that the path wasn't normalized. This PR normalizes that path variable to fix the warning. It also renames some variables from `master_*` to `meta_*` (https://github.com/gazebosim/gz-cmake/commit/6bd2d3d097e9b682d66df0af5ffbe74e53b6f6d8) for consistency and improved language and defines distinct variables for the `config_header_install_dir` and `meta_header_install_dir` (part of https://github.com/gazebosim/gz-cmake/commit/d32068da4a59c3ac878cdd6120aa6578c9eb3c2a) to clarify what each variable represents, since the "meta" header previously wasn't actually installed to `meta_header_install_dir`.

This should be tested with downstream packages, including `gz-plugin` (to confirm the cmake warning is fixed) and `sdformat` (which uses the `REPLACE_INCLUDE_PATH` option).

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
