### PR TITLE
Prepare for 4.1.1~pre1 prerelease

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake4 VERSION 4.1.0)
+project(gz-cmake4 VERSION 4.1.1)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake
@@ -20,7 +20,7 @@ include(GzCMake)
 
 #--------------------------------------
 # Set up the project
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #--------------------------------------
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo CMake 4.x
 
+### Gazebo CMake 4.1.1 (2025-02-10)
+
+1. Normalize header install path
+    * [Pull request #467](https://github.com/gazebosim/gz-cmake/pull/467)
+
+1. Ensure that find_package(TinyXML2) defines tinyxml2::tinyxml2 even on case insensitive filesystems
+    * [Pull request #465](https://github.com/gazebosim/gz-cmake/pull/465)
+
 ### Gazebo CMake 4.1.0 (2024-11-01)
 
 1. Update add-to-project version in triage.yml

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-cmake4</name>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
   <description>Gazebo CMake : CMake Modules for Gazebo Projects</description>
 
   <maintainer email="scpeters@openrobotics.org">Steve Peters</maintainer>


### PR DESCRIPTION
# 🎈 Release

Preparation for 4.1.1~pre1 prerelease.

Comparison to 4.1.0: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4_4.1.0...gz-cmake4

<!-- Add links to PRs that require this release (if needed) -->
Needed to fix #461 

## Checklist
- [X] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
