### PR TITLE
Only find python if needed

### DIFF
--- a/cmake/GzBuildTests.cmake
+++ b/cmake/GzBuildTests.cmake
@@ -123,7 +123,9 @@ macro(gz_build_tests)
 
     # Find the Python interpreter for running the
     # check_test_ran.py script
-    include(GzPython)
+    if(NOT Python3_Interpreter_FOUND)
+      include(GzPython)
+    endif()
 
     # Build all the tests
     foreach(target_name ${test_list})

--- a/cmake/GzCodeCheck.cmake
+++ b/cmake/GzCodeCheck.cmake
@@ -1,7 +1,9 @@
 # Setup the codecheck target, which will run cppcheck and cppplint.
 # This function is private to gz-cmake.
 function(_gz_setup_target_for_codecheck)
-  include(GzPython)
+  if(NOT Python3_Interpreter_FOUND)
+    include(GzPython)
+  endif()
 
   find_program(CPPCHECK_PATH cppcheck)
   find_program(FIND_PATH find)


### PR DESCRIPTION
# 🦟 Bug fix

Partial backport of find logic from https://github.com/gazebosim/gz-cmake/pull/431

## Summary

Update `GzBuildTests` and `GzCodeCheck` to only search for python if it hasn't already been found. Otherwise we might search for the wrong components.

This may fix the cmake warning unhidden by https://github.com/gazebosim/gz-math/pull/663.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
