### PR TITLE
Prepare for 3.5.5~pre1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.5.4)
+project(gz-cmake3 VERSION 3.5.5)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake
@@ -20,7 +20,7 @@ include(GzCMake)
 
 #--------------------------------------
 # Set up the project
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #--------------------------------------
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.5.5 (prerelease)
+
+1. Normalize header install path
+    * [Pull request #467](https://github.com/gazebosim/gz-cmake/pull/467)
+    * [Pull request #474](https://github.com/gazebosim/gz-cmake/pull/474)
+
+1. Only find python if needed
+    * [Pull request #473](https://github.com/gazebosim/gz-cmake/pull/473)
+
 ### Gazebo CMake 3.5.4 (2025-01-30)
 
 1. Accept arbitrary capitalization for coverage build type

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-cmake3</name>
-  <version>3.5.4</version>
+  <version>3.5.5</version>
   <description>Gazebo CMake : CMake Modules for Gazebo Projects</description>
 
   <maintainer email="scpeters@openrobotics.org">Steve Peters</maintainer>


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.5.5~pre1 release.

Comparison to 3.5.4: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.5.4...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.