### PR TITLE
Normalize header install path (backport)

### DIFF
--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -720,31 +720,42 @@ function(ign_install_all_headers)
 
     set(component_name ${ign_install_all_headers_COMPONENT})
 
-    # Define the install directory for the component meta header
-    set(meta_header_install_dir ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}/${component_name})
+    # Define the install directory for the "config" header
+    # The "meta" header will be installed one folder above this
+    set(config_header_install_dir ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}/${component_name})
 
-    # Define the input/output of the configuration for the component "master" header
-    set(master_header_in ${IGNITION_CMAKE_DIR}/ign_auto_headers.hh.in)
-    set(master_header_out ${CMAKE_CURRENT_BINARY_DIR}/${component_name}.hh)
+    # Define the input/output of the configuration for the component "meta" header
+    set(meta_header_in ${IGNITION_CMAKE_DIR}/ign_auto_headers.hh.in)
+    set(meta_header_out ${CMAKE_CURRENT_BINARY_DIR}/${component_name}.hh)
 
   else()
 
-    # Define the install directory for the core master meta header
-    set(meta_header_install_dir ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
+    # Define the install directory for the "config" header
+    # The core "meta" header will be installed one folder above this
+    set(config_header_install_dir ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR})
 
-    # Define the input/output of the configuration for the core "master" header
-    set(master_header_in ${IGNITION_CMAKE_DIR}/ign_auto_headers.hh.in)
-    set(master_header_out ${CMAKE_CURRENT_BINARY_DIR}/../${GZ_DESIGNATION}.hh)
+    # Define the input/output of the configuration for the core "meta" header
+    set(meta_header_in ${IGNITION_CMAKE_DIR}/ign_auto_headers.hh.in)
+    set(meta_header_out ${CMAKE_CURRENT_BINARY_DIR}/../${GZ_DESIGNATION}.hh)
 
   endif()
 
-  # Generate the "master" header that includes all of the headers
-  configure_file(${master_header_in} ${master_header_out})
+  # Generate the install directory for the "meta" header one folder above the "config" header
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20")
+    cmake_path(SET meta_header_install_dir NORMALIZE ${config_header_install_dir}/..)
+  else()
+    # cmake_path was added in cmake 3.20, so continue using a relative path with older versions
+    # Do not merge this forward to gz-cmake4
+    set(meta_header_install_dir ${config_header_install_dir}/..)
+  endif()
 
-  # Install the "master" header
+  # Generate the "meta" header that includes all of the headers
+  configure_file(${meta_header_in} ${meta_header_out})
+
+  # Install the "meta" header
   install(
-    FILES ${master_header_out}
-    DESTINATION ${meta_header_install_dir}/..
+    FILES ${meta_header_out}
+    DESTINATION ${meta_header_install_dir}
     COMPONENT headers)
 
   # Define the input/output of the configuration for the "config" header
@@ -770,7 +781,7 @@ function(ign_install_all_headers)
     # Install the "config" header
     install(
       FILES ${config_header_out}
-      DESTINATION ${meta_header_install_dir}
+      DESTINATION ${config_header_install_dir}
       COMPONENT headers)
 
   endif()


### PR DESCRIPTION
# 🦟 Bug fix

Manual backport of #467, #474.

## Summary

The "meta" header containing a list of all includes in the package is currently installed one folder above the other includes. This cleans up the definition of that install path by normalizing it to fix a cmake warning and also renaming some variables for clarity.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
