### PR TITLE
Prepare for 2.17.3~pre1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.17.2)
+project(ignition-cmake2 VERSION 2.17.3)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake
@@ -22,7 +22,7 @@ include(IgnCMake)
 # Set up the project
 ign_configure_project(
   REPLACE_IGNITION_INCLUDE_PATH gz/cmake
-  VERSION_SUFFIX
+  VERSION_SUFFIX pre1
 )
 
 #--------------------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.17.3 (2025-XX-XX)
+
+1. Normalize header install path (backport)
+    * [Pull request #481](https://github.com/gazebosim/gz-cmake/pull/481)
+
+1. Support for Windows conda-forge ogre-next recipe (gz-cmake2)
+    * [Pull request #464](https://github.com/gazebosim/gz-cmake/pull/464)
+
+1. Reduce example names to be able to run Conda CI on Windows (gz-cmake2)
+    * [Pull request #463](https://github.com/gazebosim/gz-cmake/pull/463)
+
+1. Accept arbitrary capitalization for coverage build type
+    * [Pull request #435](https://github.com/gazebosim/gz-cmake/pull/435)
+
 ### Gazebo CMake 2.17.2 (2024-05-07)
 
 1. Backport #402: Replace `exec_program` with `execute_process`


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.17.3~pre1 release.

Comparison to 2.17.2: https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.17.2...ign-cmake2

<!-- Add links to PRs that require this release (if needed) -->
Needed by to fix the last warnings related to #461

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.