### PR TITLE
Merge gz-cmake3 ➡️  gz-cmake4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -69,6 +69,23 @@
 
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.5.5 (2025-02-27)
+
+1. Normalize header install path
+    * [Pull request #467](https://github.com/gazebosim/gz-cmake/pull/467)
+    * [Pull request #474](https://github.com/gazebosim/gz-cmake/pull/474)
+
+1. Only find python if needed
+    * [Pull request #473](https://github.com/gazebosim/gz-cmake/pull/473)
+
+### Gazebo CMake 3.5.4 (2025-01-30)
+
+1. Accept arbitrary capitalization for coverage build type
+    * [Pull request #435](https://github.com/gazebosim/gz-cmake/pull/435)
+
+1. Fix link for Sanitizer Builds tutorial
+    * [Pull request #433](https://github.com/gazebosim/gz-cmake/pull/433)
+
 ### Gazebo CMake 3.5.3 (2024-05-02)
 
 1. Fix installation of Ign*.cmake modules on newer versions of CMake


### PR DESCRIPTION
# ➡️  Forward port

Port `gz-cmake3 ` ➡️  `gz-cmake4`

Branch comparison: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4...gz-cmake3

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)