### PR TITLE
Avoid warnings on unused CMAKE_BUILD_TYPE on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,3 +259,9 @@ gz_create_docs(
   API_MAINPAGE_MD "${CMAKE_BINARY_DIR}/api.md"
   TUTORIALS_MAINPAGE_MD "${CMAKE_BINARY_DIR}/tutorials.md"
   )
+
+# Workaround to avoid warnings when using CMAKE_BUILD_TYPE in colcon
+# to build other projects and gz-cmake together on Windows
+if(DEFINED CMAKE_BUILD_TYPE)
+  set(_dummy_var "${CMAKE_BUILD_TYPE}")
+endif()


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-plugin/issues/161

## Summary

The gz-cmake code made no use of `CMAKE_BUILD_TYPE` but the variable is set for all the packages in colcon using VS on Windows. Not an easy fix that I can think of, probably make the gz-cmake code to workaround it by consuming it and do nothing is the most practical approach. Feel free to propose better solutions.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.