### PR TITLE
Doxygen: use MARKDOWN_ID_STYLE = GITHUB

### DIFF
--- a/doc/doxygen/api.in
+++ b/doc/doxygen/api.in
@@ -319,6 +319,17 @@ EXTENSION_MAPPING      =
 
 MARKDOWN_SUPPORT       = YES
 
+# The MARKDOWN_ID_STYLE tag can be used to specify the algorithm used to
+# generate identifiers for the Markdown headings.
+# Note: Every identifier is unique. Possible values are:
+# DOXYGEN use a fixed 'autotoc_md' string followed by a sequence number
+# starting at 0 and
+# GITHUB use the lower case version of title with any whitespace replaced by
+# '-' and punctuation characters removed.
+# The default value is: DOXYGEN.
+
+MARKDOWN_ID_STYLE      = GITHUB
+
 # When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
 # to that level are automatically included in the table of contents, even if
 # they do not have an id attribute.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes errors in https://github.com/gazebosim/gz-sensors/pull/516

## Summary

This allows linking to subsections of a tutorial and fixes the following error from 
https://github.com/gazebosim/gz-sensors/pull/516:

~~~
tutorials/install.md:138: warning: unable to resolve reference to 'install-prerequisites' for \ref command
~~~

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
