### PR TITLE
Prepare for 4.2.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake4 VERSION 4.1.1)
+project(gz-cmake4 VERSION 4.2.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,22 @@
 ## Gazebo CMake 4.x
 
+### Gazebo CMake 4.2.0 (2025-04-25)
+
+1. **Baseline:** this includes all changes from 4.1.1 and earlier.
+
+1. Doxygen: use `MARKDOWN_ID_STYLE` = GITHUB
+    * [Pull request #491](https://github.com/gazebosim/gz-cmake/pull/491)
+
+1. Avoid warnings on unused `CMAKE_BUILD_TYPE` on Windows
+    * [Pull request #487](https://github.com/gazebosim/gz-cmake/pull/487)
+
+1. Integrate Ogre-Next 3.x.x built from source
+    * [Pull request #468](https://github.com/gazebosim/gz-cmake/pull/468)
+
+1. Reduce example names to be able to run Conda CI on Windows (gz-cmake4)
+    * [Pull request #476](https://github.com/gazebosim/gz-cmake/pull/476)
+    * [Pull request #478](https://github.com/gazebosim/gz-cmake/pull/478)
+
 ### Gazebo CMake 4.1.1 (2025-02-24)
 
 1. Normalize header install path

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-cmake4</name>
-  <version>4.1.1</version>
+  <version>4.2.0</version>
   <description>Gazebo CMake : CMake Modules for Gazebo Projects</description>
 
   <maintainer email="scpeters@openrobotics.org">Steve Peters</maintainer>


### PR DESCRIPTION
# 🎈 Release

Preparation for 4.2.0 release.

Comparison to 4.1.1: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4_4.1.1...gz-cmake4

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.