### PR TITLE
GzCodeCoverage: ignore lcov errors

### DIFF
--- a/cmake/GzCodeCoverage.cmake
+++ b/cmake/GzCodeCoverage.cmake
@@ -141,10 +141,14 @@ FUNCTION(gz_setup_target_for_coverage)
     # Capturing lcov counters and generating report
     COMMAND ${LCOV_PATH} ${_branch_flags} -q --no-checksum
       --directory ${PROJECT_BINARY_DIR} --capture
-      --output-file ${_outputname}.info 2>/dev/null
+      --ignore-errors gcov,gcov
+      --ignore-errors mismatch,mismatch
+      --ignore-errors unused,unused
+      --output-file ${_outputname}.info
     # Remove negative counts
     COMMAND sed -i '/,-/d' ${_outputname}.info
     COMMAND ${LCOV_PATH} ${_branch_flags} -q
+      --ignore-errors unused,unused
       --remove ${_outputname}.info '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' '*.pb.*' '*/build/*' '*/install/*' ${IGNORE_LIST} --output-file ${_outputname}.info.cleaned
     COMMAND ${GENHTML_PATH} ${_branch_flags} -q --prefix ${PROJECT_SOURCE_DIR}
     --legend -o ${_outputname} ${_outputname}.info.cleaned


### PR DESCRIPTION
# 🦟 Bug fix

Fixes some errors related to code coverage on 24.04

## Summary

Running `make coverage` currently fails on 24.04 due to lcov errors and warnings. This is difficult to see because these warnings are currently redirected to `/dev/null`. Through debugging in https://github.com/gazebosim/gz-utils/pull/174, testing with nightly builds of gz-cmake5, and viewing GitHub workflow console logs ([for example](https://github.com/gazebosim/gz-utils/actions/runs/14674649013/job/41195440316)), several types of errors were identified that could be ignored to allow `make coverage` to pass for gz-utils.

There are other issues with code coverage, specifically with uploading coverage reports (similar to https://github.com/MicrosoftPremier/VstsExtensions/issues/237). I will open a separate issue about this.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
