### PR TITLE
Merge gz-cmake3 ➡️  gz-cmake4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -335,6 +335,31 @@
 
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.17.3 (2025-XX-XX)
+
+1. Normalize header install path (backport)
+    * [Pull request #481](https://github.com/gazebosim/gz-cmake/pull/481)
+
+1. Support for Windows conda-forge ogre-next recipe (gz-cmake2)
+    * [Pull request #464](https://github.com/gazebosim/gz-cmake/pull/464)
+
+1. Reduce example names to be able to run Conda CI on Windows (gz-cmake2)
+    * [Pull request #463](https://github.com/gazebosim/gz-cmake/pull/463)
+
+1. Accept arbitrary capitalization for coverage build type
+    * [Pull request #435](https://github.com/gazebosim/gz-cmake/pull/435)
+
+### Gazebo CMake 2.17.2 (2024-05-07)
+
+1. Backport #402: Replace `exec_program` with `execute_process`
+    * [Pull request #402](https://github.com/gazebosim/gz-cmake/pull/402)
+
+1. Remove @mxgrey as codeowner and assign maintainership to @scpeters
+    * [Pull request #414](https://github.com/gazebosim/gz-cmake/pull/414)
+
+1. Update github action workflows
+    * [Pull request #395](https://github.com/gazebosim/gz-cmake/pull/395)
+
 ### Gazebo CMake 2.17.1 (2023-08-31)
 
 1. FindIgnOgre*: fix LIBRARY_DIRS and PLUGINDIR resolution when using pkgconfig


### PR DESCRIPTION
# ➡️  Forward port

  Port `gz-cmake3 ` ➡️  `gz-cmake4`

  Branch comparison: https://github.com/gazebosim/gz-cmake/compare/gz-cmake4...gz-cmake3

  **Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)